### PR TITLE
Ansible Style Guide and Overall Contribution Guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ gh-pages-commit:
 	git subtree push --prefix dist origin gh-pages
 
 build_html:
-	./scripts/to_html_template.sh index install_guide staff_guide user_guide imaging_guide connecting_cloud_provider
+	./scripts/to_html_template.sh index install_guide staff_guide user_guide imaging_guide connecting_cloud_provider contribution_guide

--- a/dist/connecting_cloud_provider.html
+++ b/dist/connecting_cloud_provider.html
@@ -34,6 +34,7 @@
                                   <aside>
                       <h3> TABLE OF CONTENTS </h3>
                       <ul>
+                      <li><a href="#connecting-a-cloud-provider-to-atmosphere">Connecting a Cloud Provider to Atmosphere</a><ul>
                       <li><a href="#overview">Overview</a></li>
                       <li><a href="#prerequisites">Prerequisites</a></li>
                       <li><a href="#procedure">Procedure</a><ul>
@@ -50,14 +51,16 @@
                       <li><a href="#grant-staffsuperuser-privileges">Grant Staff/Superuser Privileges</a></li>
                       <li><a href="#choose-an-allocation-strategy">Choose an Allocation Strategy</a></li>
                       <li><a href="#add-openstacks-imagesinstancessizes-to-atmosphere">Add OpenStack’s Images/Instances/Sizes to Atmosphere</a></li>
-                      <li><a href="#update-atmosphere-ansible-hosts-file">Update atmosphere-ansible hosts file</a></li>
+                      <li><a href="#update-atmosphere-ansible-hosts-file-and-group_vars">Update atmosphere-ansible hosts file and group_vars</a></li>
                       <li><a href="#test-atmosphere">Test Atmosphere!</a></li>
+                      </ul></li>
                       </ul></li>
                       </ul></li>
                       </ul>
                   </aside>
                               <!-- MAIN CONTENT -->
               <article>
+              <h1 id="connecting-a-cloud-provider-to-atmosphere">Connecting a Cloud Provider to Atmosphere</h1>
               <h2 id="overview">Overview</h2>
               <p>This guide will help you connect Atmosphere to an OpenStack cloud. Atmosphere connects to OpenStack APIs using both LibCloud and the OpenStack client tools.</p>
               <p>This is a work in progress, see Chris Martin or Steve Gregory with questions.</p>
@@ -335,13 +338,14 @@
               monitor_sizes_for(8)
               monitor_machines_for(8)
               monitor_instances_for(8)  # Only necessary if `nova boot` was done out-of-band</code></pre>
-              <h4 id="update-atmosphere-ansible-hosts-file">Update atmosphere-ansible hosts file</h4>
+              <h4 id="update-atmosphere-ansible-hosts-file-and-group_vars">Update atmosphere-ansible hosts file and group_vars</h4>
               <p>Ensure that the hostnames of all your VMs are in <code>/opt/dev/atmosphere-ansible/ansible/hosts</code>, e.g.:</p>
               <pre><code>[atmosphere:children]
               atmosphere-mytestcloud
               
               [atmosphere-mytestcloud]
               vm7.mytestcloud.cyverse.org ansible_host=128.196.171.7 ansible_port=22</code></pre>
+              <p>Also ensure that you have appropriate group_vars defined in <code>/opt/dev/atmosphere-ansible/ansible/group/vars/name-of-your-cloud</code>.</p>
               <h4 id="test-atmosphere">Test Atmosphere!</h4>
               <p>In Atmosphere, try logging into the Troposphere UI as the account you added, selecting an image, and launching an instance.</p>
               </article>

--- a/dist/contribution_guide.html
+++ b/dist/contribution_guide.html
@@ -130,7 +130,7 @@
               <li>Have a name ending in <code>.yml</code></li>
               <li>Begin with three dashes followed by a blank line</li>
               <li>Use 2-space indents</li>
-              <li>Use YAML dictionary format ratner than in-line module arguments. So, this:</li>
+              <li>Use YAML dictionary format rather than in-line module arguments. So, this:</li>
               </ul>
               <pre><code>- name: foo
                 file:

--- a/dist/contribution_guide.html
+++ b/dist/contribution_guide.html
@@ -79,12 +79,18 @@
                       </ul></li>
                       </ul></li>
                       <li><a href="#ansible-style-guidelines">Ansible Style Guidelines</a><ul>
-                      <li><a href="#optionally-defined-variables">Optionally Defined Variables</a></li>
-                      <li><a href="#ansible-galaxy-roles">Ansible Galaxy Roles</a><ul>
+                      <li><a href="#yaml-files-and-formatting">YAML Files and Formatting</a></li>
+                      <li><a href="#variables">Variables</a></li>
+                      <li><a href="#conditional-logic">Conditional Logic</a></li>
+                      <li><a href="#modules">Modules</a></li>
+                      <li><a href="#files-and-installation-packages">Files and Installation Packages</a></li>
+                      <li><a href="#ansible-security-guidelines">Ansible Security Guidelines</a></li>
+                      <li><a href="#maybe-guidelines-things-to-discuss">Maybe Guidelines? Things to discuss?</a></li>
+                      </ul></li>
+                      <li><a href="#about-ansible-galaxy-roles">About Ansible Galaxy Roles</a><ul>
                       <li><a href="#identifying-and-working-with-galaxy-roles">Identifying and Working With Galaxy Roles</a></li>
                       <li><a href="#installing-consuming-galaxy-roles-in-another-project">Installing (Consuming) Galaxy Roles in Another Project</a></li>
                       <li><a href="#importing-contributing-a-role-to-galaxy">Importing (Contributing) a Role to Galaxy</a></li>
-                      </ul></li>
                       </ul></li>
                       </ul></li>
                       </ul>
@@ -122,10 +128,38 @@
               <li>Local libraries</li>
               </ol>
               <h2 id="ansible-style-guidelines">Ansible Style Guidelines</h2>
-              <p>These apply to repos like clank and atmosphere-ansible (collectively, “the Ansible projects”).</p>
-              <h3 id="optionally-defined-variables">Optionally Defined Variables</h3>
-              <p>Instead of using the <code>| default()</code></p>
-              <h3 id="ansible-galaxy-roles">Ansible Galaxy Roles</h3>
+              <p>These apply to repos like clank and atmosphere-ansible (collectively, “the Ansible projects”). Some are borrowed from <a href="https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions">Open edX Operations</a> and <a href="http://docs.openstack.org/developer/openstack-ansible/developer-docs/contribute.html">OpenStack-Ansible</a>.</p>
+              <h3 id="yaml-files-and-formatting">YAML Files and Formatting</h3>
+              <p>YAML files should: - Have a name ending in <code>.yml</code> - Begin with three dashes followed by a blank line - Use 2-space indents - Use YAML dictionary format ratner than in-line module arguments. So, this: <code>- name: foo     file:       src: /tmp/bar       dest: /tmp/baz       state: present</code> Not this: <code>- name: foo src=/tmp/bar dest=/tmp/baz state=present</code> - Use YAML <a href="http://yaml.org/spec/1.2/spec.html#id2796251">folded style</a> for long lines: <code>- shell: &gt;             python a very long command --with=very --long-options=foo             --and-even=more_options --like-these</code></p>
+              <h3 id="variables">Variables</h3>
+              <ul>
+              <li>Use spaces between double-braces and variable names: <code>{{ var }}</code> instead of <code>{{var}}</code></li>
+              <li>Bare variables in YAML must be quoted, e.g. ```</li>
+              <li>foo: “{{ bar }}” ```</li>
+              <li><p>For variables that have some default and are optionally overridden by a consumer/deployer: define the variable’s default value in the role <code>defaults/</code> instead of using the <code>| default()</code> jinja2 filter. This keeps configuration separate from code.</p></li>
+              <li><p>Prefix task names with the role name?</p></li>
+              </ul>
+              <h3 id="conditional-logic">Conditional Logic</h3>
+              <ul>
+              <li>To conditionally include or exclude a role, use the following syntax in a playbook: <code>roles: - { role: ldap, when: CONFIGURE_LDAP == true }</code> Avoid applying the same tag to every task in a role and expecting a user to skip a role with <code>--skip-tags</code>.</li>
+              </ul>
+              <h3 id="modules">Modules</h3>
+              <ul>
+              <li>Use <code>command</code> rather than <code>shell</code> unless shell is explicitly required (<a href="http://docs.ansible.com/ansible/shell_module.html#notes">source 0</a> <a href="https://blog.confirm.ch/ansible-modules-shell-vs-command/">source 1</a>).</li>
+              </ul>
+              <h3 id="files-and-installation-packages">Files and Installation Packages</h3>
+              <p>Avoid storing large binary files or installation packages in Ansible projects / version control. Instead, host it externally (e.g. CyVerse’s S3 account) and download from there, or download from the publisher.</p>
+              <h3 id="ansible-security-guidelines">Ansible Security Guidelines</h3>
+              <p>Do not store anything secret or sensitive (e.g. passwords, SSH private keys, license keys) in public version control. Any secrets stored in private version control should be encrypted with Ansible Vault, and Vault passphrases should not be stored in plaintext.</p>
+              <p>Any installation packages should be downloaded in a secure way that prevents man-in-the-middle attacks from changing the contents (e.g. HTTPS, or APT packages signed with a GPG key).</p>
+              <p>Avoid disabling SSH host key checking.</p>
+              <h3 id="maybe-guidelines-things-to-discuss">Maybe Guidelines? Things to discuss?</h3>
+              <ul>
+              <li><p>Variables that are internal to a role should be in lowercase? Variables that are environment-specific and should be overridden in UPPERCASE?</p></li>
+              <li><p>Prefix all variables defined in a role with the name of the role? Since Ansible doesn’t really have variable scoping?</p></li>
+              <li><p>Separate words in role names with dashes (<code>my-role</code>)?</p></li>
+              </ul>
+              <h2 id="about-ansible-galaxy-roles">About Ansible Galaxy Roles</h2>
               <p>The Ansible projects will use similar code to perform very similar tasks, so there is an effort to structure our code into modular, re-usable roles. These roles are generally hosted in the <a href="https://github.com/cyverse-ansible">CyVerse-Ansible</a> organization and consumed via <a href="https://galaxy.ansible.com/">Ansible Galaxy</a>. This will centralize the development/maintenance effort and provide easy consumption by any interested groups. New Ansible contributors are encouraged to read <a href="https://galaxy.ansible.com/intro">Ansible Galaxy Intro</a>.</p>
               <h4 id="identifying-and-working-with-galaxy-roles">Identifying and Working With Galaxy Roles</h4>
               <p>The Ansible projects include a mix of roles installed from Galaxy and roles defined locally. The following clues should indicate that a given role was installed from Galaxy.</p>

--- a/dist/contribution_guide.html
+++ b/dist/contribution_guide.html
@@ -73,9 +73,6 @@
                       <ul>
                       <li><a href="#atmosphere-contribution-guide">Atmosphere Contribution Guide</a><ul>
                       <li><a href="#code-guidelines">Code Guidelines</a><ul>
-                      <li><a href="#python-style-guidelines">Python Style Guidelines</a><ul>
-                      <li><a href="#import-ordering">Import ordering</a></li>
-                      </ul></li>
                       <li><a href="#ansible-style-guidelines">Ansible Style Guidelines</a><ul>
                       <li><a href="#yaml-files-and-formatting">YAML Files and Formatting</a></li>
                       <li><a href="#variables">Variables</a></li>
@@ -90,6 +87,23 @@
                       <li><a href="#contribution-guide-contribution-guide">Contribution Guide Contribution Guide</a></li>
                       <li><a href="#further-reading">Further Reading</a></li>
                       </ul></li>
+                      <li><a href="#python">Python</a><ul>
+                      <li><a href="#naming">Naming</a><ul>
+                      <li><a href="#general-naming-guidelines">General Naming Guidelines</a></li>
+                      </ul></li>
+                      <li><a href="#indentation">Indentation</a></li>
+                      <li><a href="#imports">Imports</a></li>
+                      <li><a href="#string-formatting">String formatting</a></li>
+                      <li><a href="#print-statements">Print statements</a></li>
+                      <li><a href="#documentation">Documentation</a></li>
+                      <li><a href="#on-comments">On Comments</a><ul>
+                      <li><a href="#method-overrides">Method Overrides</a></li>
+                      </ul></li>
+                      <li><a href="#calling-superclasses-methods">Calling Superclasses’ Methods</a></li>
+                      <li><a href="#line-lengths">Line lengths</a></li>
+                      <li><a href="#recommended-syntax-checkers">Recommended Syntax Checkers</a></li>
+                      <li><a href="#credits">Credits</a></li>
+                      </ul></li>
                       </ul>
                   </aside>
                               <!-- MAIN CONTENT -->
@@ -100,28 +114,6 @@
               <ul>
               <li><a href="https://late.am/post/2016/04/28/delete-your-dead-code.html">Delete your dead code</a>. If you know that code is not run, don’t comment it out, instead remove it completely. Old code remains in version control and we can dig into the past if needed.</li>
               </ul>
-              <h3 id="python-style-guidelines">Python Style Guidelines</h3>
-              <ul>
-              <li>Use 4 space indentation</li>
-              <li>Limit lines to 79 characters</li>
-              <li>Remove unused imports</li>
-              <li>Remove trailing whitespace</li>
-              <li>See <a href="https://www.python.org/dev/peps/pep-0008/">PEP8 - Style Guide for Python Code</a></li>
-              </ul>
-              <p>It is recommended that you use the git <code>pre-commit</code> hook to ensure your code is compliant with our style guide.</p>
-              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">ln</span> -s <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/contrib/pre-commit.hook <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/.git/hooks/pre-commit</code></pre></div>
-              <p>To automate running tests before a push use the git <code>pre-push</code> hook to ensure your code passes all the tests.</p>
-              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">ln</span> -s <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/contrib/pre-push.hook <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>.git/hooks/pre-push</code></pre></div>
-              <p>When master is pulled, it’s helpful to know if a <code>pip install</code> or a <code>manage.py migrate</code> is necessary. To get other helpful warnings:</p>
-              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">ln</span> -s <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/contrib/post-merge.hook <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/.git/hooks/post-merge</code></pre></div>
-              <h4 id="import-ordering">Import ordering</h4>
-              <p>Imports should be grouped into the sections below and in sorted order.</p>
-              <ol style="list-style-type: decimal">
-              <li>Standard libraries</li>
-              <li>Third-party libraries</li>
-              <li>External project libraries</li>
-              <li>Local libraries</li>
-              </ol>
               <h3 id="ansible-style-guidelines">Ansible Style Guidelines</h3>
               <p>These apply to repos such as clank and atmosphere-ansible (collectively, “the Ansible projects”). Some are borrowed from <a href="https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions">Open edX Operations</a> and <a href="http://docs.openstack.org/developer/openstack-ansible/developer-docs/contribute.html">OpenStack-Ansible</a>.</p>
               <h4 id="yaml-files-and-formatting">YAML Files and Formatting</h4>
@@ -213,6 +205,217 @@
               <h2 id="further-reading">Further Reading</h2>
               <ul>
               <li><a href="http://wiki.c2.com/?CodeSmell">Code Smells</a></li>
+              </ul>
+              <h1 id="python">Python</h1>
+              <p>This Python style guide is largely copied from <a href="http://cosdev.readthedocs.io/en/latest/style_guides/python.html">Center for Open Science</a></p>
+              <p>Follow <a href="http://www.python.org/dev/peps/pep-0008/">PEP8</a>, when sensible.</p>
+              <h2 id="naming">Naming</h2>
+              <ul>
+              <li>Variables, functions, methods, packages, modules
+              <ul>
+              <li><code>lower_case_with_underscores</code></li>
+              </ul></li>
+              <li>Classes and Exceptions
+              <ul>
+              <li><code>CapWords</code></li>
+              </ul></li>
+              <li>Protected methods and internal functions
+              <ul>
+              <li><code>_single_leading_underscore(self, ...)</code></li>
+              </ul></li>
+              <li>Private methods
+              <ul>
+              <li><code>__double_leading_underscore(self, ...)</code></li>
+              </ul></li>
+              <li>Constants
+              <ul>
+              <li><code>ALL_CAPS_WITH_UNDERSCORES</code></li>
+              </ul></li>
+              </ul>
+              <h3 id="general-naming-guidelines">General Naming Guidelines</h3>
+              <p>Use singlequotes for strings, unless doing so requires lots of escaping.</p>
+              <p>Avoid one-letter variables (esp. <code>l</code>, <code>O</code>, <code>I</code>).</p>
+              <p><em>Exception</em>: In very short blocks, when the meaning is clearly visible from the immediate context</p>
+              <pre class="sourcecode"><code>for e in elements:
+                  e.mutate()</code></pre>
+              <p>Avoid redundant labeling.</p>
+              <pre class="sourcecode"><code># Yes
+              import audio
+              
+              core = audio.Core()
+              controller = audio.Controller()
+              
+              # No
+              import audio
+              
+              core = audio.AudioCore()
+              controller = audio.AudioController()</code></pre>
+              <p>Prefer “reverse notation”.</p>
+              <pre class="sourcecode"><code># Yes
+              elements = ...
+              elements_active = ...
+              elements_defunct = ...
+              
+              # No
+              elements = ...
+              active_elements = ...
+              defunct_elements ...</code></pre>
+              <p>Avoid getter and setter methods.</p>
+              <pre class="sourcecode"><code># Yes
+              person.age = 42
+              
+              # No
+              person.set_age(42)</code></pre>
+              <h2 id="indentation">Indentation</h2>
+              <p>Use 4 spaces–never tabs. You may need to change the settings in your text editor of choice.</p>
+              <h2 id="imports">Imports</h2>
+              <p>Import entire modules instead of individual symbols within a module. For example, for a top-level module canteen that has a file canteen/sessions.py,</p>
+              <pre class="sourcecode"><code># Yes
+              
+              import canteen
+              import canteen.sessions
+              from canteen import sessions
+              
+              # No
+              from canteen import get_user  # Symbol from canteen/__init__.py
+              from canteen.sessions import get_session  # Symbol from canteen/sessions.py</code></pre>
+              <p><em>Exception</em>: For third-party code where documentation explicitly says to import individual symbols.</p>
+              <p><em>Rationale</em>: Avoids circular imports. See <a href="https://sites.google.com/a/khanacademy.org/forge/for-developers/styleguide/python#TOC-Imports">here</a>.</p>
+              <p>Put all imports at the top of the page with three sections, each separated by a blank line, in this order:</p>
+              <ol style="list-style-type: decimal">
+              <li>System imports</li>
+              <li>Third-party imports</li>
+              <li>Local source tree imports</li>
+              </ol>
+              <p><em>Rationale</em>: Makes it clear where each module is coming from.</p>
+              <p>If you have intentionally have an unused import that exists only to make imports less verbose, be explicit about it. This will make sure that someone doesn’t accidentally remove the import (not to mention that it keeps linters happy)</p>
+              <pre class="sourcecode"><code>from my.very.distant.module import Frob
+              
+              Frob = Frob</code></pre>
+              <h2 id="string-formatting">String formatting</h2>
+              <p>Prefer <code>str.format</code> to “%-style” formatting.</p>
+              <pre class="sourcecode"><code># Yes
+              &#39;Hello {}&#39;.format(&#39;World&#39;)
+               # OR
+              &#39;Hello {name}&#39;.format(name=&#39;World&#39;)
+              
+              # No
+              
+              &#39;Hello %s&#39; % (&#39;World&#39;, )</code></pre>
+              <h2 id="print-statements">Print statements</h2>
+              <p>Use the <code>print()</code> function rather than the <code>print</code> keyword (even if you’re using Python 2).</p>
+              <pre class="sourcecode"><code># Yes
+              print(&#39;Hello {}&#39;.format(name))
+              
+              # No
+              print &#39;Hello %s &#39; % name</code></pre>
+              <h2 id="documentation">Documentation</h2>
+              <p>Follow <a href="http://www.python.org/dev/peps/pep-0257/">PEP257</a>’s docstring guidelines. <a href="http://docutils.sourceforge.net/docs/user/rst/quickref.html">reStructured Text</a> and <a href="http://sphinx-doc.org/">Sphinx</a> can help to enforce these standards.</p>
+              <p>All functions should have a docstring - for very simple functions, one line may be enough:</p>
+              <pre><code>&quot;&quot;&quot;Return the pathname of ``foo``.&quot;&quot;&quot;</code></pre>
+              <p>Multiline docstrings should include:</p>
+              <ul>
+              <li>Summary line</li>
+              <li>Use case, if appropriate</li>
+              <li>Args</li>
+              <li>Return type and semantics, unless <code>None</code> is returned</li>
+              </ul>
+              <!-- -->
+              <pre><code>&quot;&quot;&quot;Train a model to classify Foos and Bars.
+              
+              Usage::
+              
+                  &gt;&gt;&gt; import klassify
+                  &gt;&gt;&gt; data = [(&quot;green&quot;, &quot;foo&quot;), (&quot;orange&quot;, &quot;bar&quot;)]
+                  &gt;&gt;&gt; classifier = klassify.train(data)
+              
+              :param train_data: A list of tuples of the form ``(color, label)``.
+              :return: A trained :class:`Classifier &lt;Classifier&gt;`
+              &quot;&quot;&quot;</code></pre>
+              <p>Notes</p>
+              <ul>
+              <li>Use action words (“Return”) rather than descriptions (“Returns”).</li>
+              <li>Document <code>__init__</code> methods in the docstring for the class.</li>
+              </ul>
+              <pre class="sourcecode"><code>class Person(object):
+                  &quot;&quot;&quot;A simple representation of a human being.
+              
+                  :param name: A string, the person&#39;s name.
+                  :param age: An int, the person&#39;s age.
+                  &quot;&quot;&quot;
+                  def __init__(self, name, age):
+                      self.name = name
+                      self.age = age</code></pre>
+              <h2 id="on-comments">On Comments</h2>
+              <p>Use them sparingly. Prefer code readability to writing a lot of comments. Often, small methods and functions are more effective than comments.</p>
+              <pre class="sourcecode"><code># Yes
+              def is_stop_sign(sign):
+                  return sign.color == &#39;red&#39; and sign.sides == 8
+              
+              if is_stop_sign(sign):
+                  stop()
+              
+              # No
+              # If the sign is a stop sign
+              if sign.color == &#39;red&#39; and sign.sides == 8:
+                  stop()</code></pre>
+              <p>When you do write comments, use them to explain <em>why</em> a piece code was used, not <em>what</em> it does.</p>
+              <h3 id="method-overrides">Method Overrides</h3>
+              <p>One useful place for comments are method overrides.</p>
+              <pre class="sourcecode"><code>class UserDetail(generics.RetrieveUpdateAPIView, UserMixin):
+              
+                  # overrides RetrieveUpdateAPIView
+                  def get_serializer_context(self):
+                      return {&#39;request&#39;: self.request}</code></pre>
+              <h2 id="calling-superclasses-methods">Calling Superclasses’ Methods</h2>
+              <p>Use super when there is only one superclass.</p>
+              <pre class="sourcecode"><code>class Employee(Person):
+              
+                  def __init__(self, name):
+                      super(Employee, self).__init__(name)
+                      # or super().__init__(name) in Python 3
+                      # ...</code></pre>
+              <p>Call the method directly when there are multiple superclasses.</p>
+              <pre class="sourcecode"><code>class DevOps(Developer, Operations):
+              
+                  def __init__(self):
+                      Developer.__init__(self)
+                      # ...</code></pre>
+              <h2 id="line-lengths">Line lengths</h2>
+              <p>Don’t stress over it. 80-100 characters is fine.</p>
+              <p>Use parentheses for line continuations.</p>
+              <pre class="sourcecode"><code>wiki = (
+                  &quot;The Colt Python is a .357 Magnum caliber revolver formerly manufactured &quot;
+                  &quot;by Colt&#39;s Manufacturing Company of Hartford, Connecticut. It is sometimes &quot;
+                  &#39;referred to as a &quot;Combat Magnum&quot;. It was first introduced in 1955, the &#39;
+                  &quot;same year as Smith &amp; Wesson&#39;s M29 .44 Magnum.&quot;
+              )</code></pre>
+              <h2 id="recommended-syntax-checkers">Recommended Syntax Checkers</h2>
+              <p>We recommend using a syntax checker to help you find errors quickly and easily format your code to abide by the guidelines above. <a href="http://flake8.readthedocs.org/en/latest/">Flake8</a> is our recommended checker for Python. It will check for both syntax and style errors and is easily configurable. It can be installed with pip: :</p>
+              <pre><code>$ pip install flake8</code></pre>
+              <p>Once installed, you can run a check with: :</p>
+              <pre><code>$ flake8</code></pre>
+              <p>There are a number of plugins for integrating Flake8 with your preferred text editor.</p>
+              <p>Vim</p>
+              <ul>
+              <li><a href="https://github.com/scrooloose/syntastic">syntastic</a> (multi-language)</li>
+              </ul>
+              <p>Sublime Text</p>
+              <ul>
+              <li><a href="https://sublime.wbond.net/packages/SublimeLinter">Sublime Linter</a> with <a href="https://sublime.wbond.net/packages/SublimeLinter-flake8">SublimeLinter-flake8</a> (must install both)</li>
+              </ul>
+              <p>It is recommended that you use the git <code>pre-commit</code> hook to ensure your code is compliant with our style guide.</p>
+              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="fu">ln</span> -s <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>/contrib/pre-commit.hook <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>/.git/hooks/pre-commit</code></pre></div>
+              <p>To automate running tests before a push use the git <code>pre-push</code> hook to ensure your code passes all the tests.</p>
+              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="fu">ln</span> -s <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>/contrib/pre-push.hook <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>.git/hooks/pre-push</code></pre></div>
+              <p>When master is pulled, it’s helpful to know if a <code>pip install</code> or a <code>manage.py migrate</code> is necessary. To get other helpful warnings:</p>
+              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="fu">ln</span> -s <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>/contrib/post-merge.hook <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>/.git/hooks/post-merge</code></pre></div>
+              <h2 id="credits">Credits</h2>
+              <ul>
+              <li><a href="http://cosdev.readthedocs.io/en/latest/style_guides/python.html">Center for Open Science</a></li>
+              <li><a href="http://www.python.org/dev/peps/pep-0008/">PEP8</a> (Style Guide for Python)</li>
+              <li><a href="http://www.nilunder.com/blog/2013/08/03/pythonic-sensibilities/">Pythonic Sensibilities</a></li>
+              <li><a href="http://youtu.be/GZNUfkVIHAY">Python Best Practice Patterns</a></li>
               </ul>
               </article>
             </div> <!-- #main -->

--- a/dist/contribution_guide.html
+++ b/dist/contribution_guide.html
@@ -76,6 +76,7 @@
                       <li><a href="#ansible-style-guidelines">Ansible Style Guidelines</a><ul>
                       <li><a href="#yaml-files-and-formatting">YAML Files and Formatting</a></li>
                       <li><a href="#variables">Variables</a></li>
+                      <li><a href="#tasks">Tasks</a></li>
                       <li><a href="#conditional-logic">Conditional Logic</a></li>
                       <li><a href="#modules">Modules</a></li>
                       <li><a href="#files-and-installation-packages">Files and Installation Packages</a></li>
@@ -122,7 +123,7 @@
               <li>Have a name ending in <code>.yml</code></li>
               <li>Begin with three dashes followed by a blank line</li>
               <li>Use 2-space indents</li>
-              <li>Use YAML dictionary format rather than in-line module arguments. So, this:</li>
+              <li>Use YAML dictionary format rather than in-line <code>key=value</code>s. It’s easier to read and reduces changeset collisions in version control. So, do this:</li>
               </ul>
               <pre><code>- name: foo
                 file:
@@ -141,6 +142,7 @@
               <h4 id="variables">Variables</h4>
               <ul>
               <li>Use spaces between double-braces and variable names: <code>{{ var }}</code> instead of <code>{{var}}</code></li>
+              <li>For boolean variables, use un-quoted <code>true</code> and <code>false</code></li>
               <li>Bare variables in YAML must be quoted, e.g.</li>
               </ul>
               <pre><code>- foo: &quot;{{ bar }}&quot;</code></pre>
@@ -163,6 +165,8 @@
                   - &quot;{{ ansible_distribution }}.yml&quot;</code></pre>
               <p>Matching is most-specific to least-specific, so with the above example, a role targeting an Ubuntu 16.04 system would include the variables defined in Ubuntu-16.yml, while a role targeting Ubuntu 14.04 would include the variables defined in Ubuntu.yml. Also, only one file will match and there is no concept of inheritance (so usually, the same variables should be defined in each file).</p>
               <p>Role-specific variables that do not vary per-distro can still be defined in <code>vars/main.yml</code> or <code>defaults/main.yml</code>.</p>
+              <h4 id="tasks">Tasks</h4>
+              <p>Name your tasks to reflect the completed action in the past tense: <code>denyhosts stopped and disabled</code> rather than <code>stop and disable denyhosts</code>. This reinforces the goal of defining a series of idempotent steps to either reach or confirm a desired end state.</p>
               <h4 id="conditional-logic">Conditional Logic</h4>
               <ul>
               <li>To conditionally include or exclude a role, use the following syntax in a playbook:</li>
@@ -177,7 +181,9 @@
               <p>Avoid storing large binary files or installation packages in Ansible projects / version control. Instead, host it externally (e.g. CyVerse’s S3 account) and download from there, or download from the publisher.</p>
               <h4 id="possible-ansible-guidelines---things-to-discuss">Possible Ansible Guidelines - Things to Discuss</h4>
               <ul>
-              <li>Variables that are internal to a role should be in lowercase? Variables that are environment-specific and should be overridden in UPPERCASE?</li>
+              <li><a href="https://github.com/whitecloud/ansible-styleguide#quotes">Quote all strings and prefer single quotes over double quotes</a>?</li>
+              <li>Define a <a href="https://github.com/whitecloud/ansible-styleguide#task-declaration">general order for a task declaration</a>?</li>
+              <li>Variables that are internal to a role should be in snake_case? Variables that are environment-specific and should be overridden in UPPERCASE?</li>
               <li>When to use a role’s <code>vars/</code> vs. <code>defaults/</code> directory? <code>vars/</code> for things internal to the role (e.g. distro-specific), <code>defaults/</code> for things expected to be overridden by a consumer?</li>
               <li>Prefix all variables defined in a role with the name of the role to avoid collisions?</li>
               <li>Prefix task names with the role name, to ease human parsing of log output?</li>
@@ -405,11 +411,11 @@
               <li><a href="https://sublime.wbond.net/packages/SublimeLinter">Sublime Linter</a> with <a href="https://sublime.wbond.net/packages/SublimeLinter-flake8">SublimeLinter-flake8</a> (must install both)</li>
               </ul>
               <p>It is recommended that you use the git <code>pre-commit</code> hook to ensure your code is compliant with our style guide.</p>
-              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="fu">ln</span> -s <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>/contrib/pre-commit.hook <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>/.git/hooks/pre-commit</code></pre></div>
+              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">ln</span> -s <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/contrib/pre-commit.hook <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/.git/hooks/pre-commit</code></pre></div>
               <p>To automate running tests before a push use the git <code>pre-push</code> hook to ensure your code passes all the tests.</p>
-              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="fu">ln</span> -s <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>/contrib/pre-push.hook <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>.git/hooks/pre-push</code></pre></div>
+              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">ln</span> -s <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/contrib/pre-push.hook <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>.git/hooks/pre-push</code></pre></div>
               <p>When master is pulled, it’s helpful to know if a <code>pip install</code> or a <code>manage.py migrate</code> is necessary. To get other helpful warnings:</p>
-              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="fu">ln</span> -s <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>/contrib/post-merge.hook <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>/.git/hooks/post-merge</code></pre></div>
+              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">ln</span> -s <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/contrib/post-merge.hook <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/.git/hooks/post-merge</code></pre></div>
               <h2 id="credits">Credits</h2>
               <ul>
               <li><a href="http://cosdev.readthedocs.io/en/latest/style_guides/python.html">Center for Open Science</a></li>

--- a/dist/contribution_guide.html
+++ b/dist/contribution_guide.html
@@ -73,11 +73,19 @@
                       <ul>
                       <li><a href="#atmosphere-contribution-guide">Atmosphere Contribution Guide</a><ul>
                       <li><a href="#overview">Overview</a><ul>
+                      <li><a href="#general-guidelines">General Guidelines</a></li>
                       <li><a href="#python-style-guidelines">Python Style Guidelines</a><ul>
                       <li><a href="#import-ordering">Import ordering</a></li>
                       </ul></li>
                       </ul></li>
-                      <li><a href="#ansible-style-guidelines">Ansible Style Guidelines</a></li>
+                      <li><a href="#ansible-style-guidelines">Ansible Style Guidelines</a><ul>
+                      <li><a href="#optionally-defined-variables">Optionally Defined Variables</a></li>
+                      <li><a href="#ansible-galaxy-roles">Ansible Galaxy Roles</a><ul>
+                      <li><a href="#identifying-and-working-with-galaxy-roles">Identifying and Working With Galaxy Roles</a></li>
+                      <li><a href="#installing-consuming-galaxy-roles-in-another-project">Installing (Consuming) Galaxy Roles in Another Project</a></li>
+                      <li><a href="#importing-contributing-a-role-to-galaxy">Importing (Contributing) a Role to Galaxy</a></li>
+                      </ul></li>
+                      </ul></li>
                       </ul></li>
                       </ul>
                   </aside>
@@ -85,6 +93,12 @@
               <article>
               <h1 id="atmosphere-contribution-guide">Atmosphere Contribution Guide</h1>
               <h2 id="overview">Overview</h2>
+              <p>These guidelines will improve the consistency and comprehensibility of our code.</p>
+              <p>New contributions to “the Atmosphere projects” (atmosphere, troposphere, atmosphere-ansible, clank, etc) are generally expected to follow these guidelines, and future pull requests will be checked for adherence.</p>
+              <h3 id="general-guidelines">General Guidelines</h3>
+              <ul>
+              <li><a href="https://late.am/post/2016/04/28/delete-your-dead-code.html">Delete your dead code</a>. If you know that code is not run, don’t comment it out, instead remove it completely. Old code remains in version control and we can dig into the past if needed.</li>
+              </ul>
               <h3 id="python-style-guidelines">Python Style Guidelines</h3>
               <ul>
               <li>Use 4 space indentation</li>
@@ -108,6 +122,22 @@
               <li>Local libraries</li>
               </ol>
               <h2 id="ansible-style-guidelines">Ansible Style Guidelines</h2>
+              <p>These apply to repos like clank and atmosphere-ansible (collectively, “the Ansible projects”).</p>
+              <h3 id="optionally-defined-variables">Optionally Defined Variables</h3>
+              <p>Instead of using the <code>| default()</code></p>
+              <h3 id="ansible-galaxy-roles">Ansible Galaxy Roles</h3>
+              <p>The Ansible projects will use similar code to perform very similar tasks, so there is an effort to structure our code into modular, re-usable roles. These roles are generally hosted in the <a href="https://github.com/cyverse-ansible">CyVerse-Ansible</a> organization and consumed via <a href="https://galaxy.ansible.com/">Ansible Galaxy</a>. This will centralize the development/maintenance effort and provide easy consumption by any interested groups. New Ansible contributors are encouraged to read <a href="https://galaxy.ansible.com/intro">Ansible Galaxy Intro</a>.</p>
+              <h4 id="identifying-and-working-with-galaxy-roles">Identifying and Working With Galaxy Roles</h4>
+              <p>The Ansible projects include a mix of roles installed from Galaxy and roles defined locally. The following clues should indicate that a given role was installed from Galaxy.</p>
+              <ul>
+              <li>The role is defined in the project’s <code>requirements.yml</code></li>
+              <li>The role contains <code>meta/galaxy_install_info</code> and <code>meta/main.yml</code></li>
+              </ul>
+              <p>There is a clear concept of “upstream” (roles) and “downstream” (projects that consume them), so generally we should <em>avoid making persistent changes</em> to a role which has been installed from Galaxy <em>inside a repository that consumes it</em>. Such changes will 1. not propagate back upstream to the role repository, and 2. be overwritten the next time the role is updated from Galaxy. Instead, make your changes in the upstream Ansible role (see below), re-import it, and install the new version in the consuming repository.</p>
+              <h4 id="installing-consuming-galaxy-roles-in-another-project">Installing (Consuming) Galaxy Roles in Another Project</h4>
+              <p>The Ansible projects use a <code>requirements.yml</code> file to define the Galaxy roles we are consuming. Install new roles and update existing roles in a repo by running <code>ansible-galaxy install -f -r requirements.yml -p roles/</code> from the <code>ansible</code> folder. Then, the desired roles will be copied into your project, and you can call them from Playbooks like any other role.</p>
+              <h4 id="importing-contributing-a-role-to-galaxy">Importing (Contributing) a Role to Galaxy</h4>
+              <p>Follow the instructions in <a href="https://github.com/CyVerse-Ansible/ansible-role-template">this template</a> to publish an Ansible role to Galaxy and set up automated testing with Travis CI; then you can install the role into other projects.</p>
               </article>
             </div> <!-- #main -->
         </div> <!-- #main-container -->

--- a/dist/contribution_guide.html
+++ b/dist/contribution_guide.html
@@ -144,7 +144,8 @@
               </ul>
               <pre><code>- shell: &gt;
                       python a very long command --with=very --long-options=foo
-                      --and-even=more_options --like-these</code></pre>
+                      --and-even=more_options --like-these
+              </code></pre>
               <h4 id="variables">Variables</h4>
               <ul>
               <li>Use spaces between double-braces and variable names: <code>{{ var }}</code> instead of <code>{{var}}</code></li>

--- a/dist/contribution_guide.html
+++ b/dist/contribution_guide.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang=""> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8" lang=""> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9" lang=""> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang=""> <!--<![endif]-->
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta http-equiv="Content-Style-Type" content="text/css" />
+        <meta name="generator" content="pandoc" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+                    <title></title>
+        <style type="text/css">code{white-space: pre;}</style>
+                    <style type="text/css">
+      div.sourceCode { overflow-x: auto; }
+      table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode {
+        margin: 0; padding: 0; vertical-align: baseline; border: none; }
+      table.sourceCode { width: 100%; line-height: 100%; }
+      td.lineNumbers { text-align: right; padding-right: 4px; padding-left: 4px; color: #aaaaaa; border-right: 1px solid #aaaaaa; }
+      td.sourceCode { padding-left: 5px; }
+      code > span.kw { color: #007020; font-weight: bold; } /* Keyword */
+      code > span.dt { color: #902000; } /* DataType */
+      code > span.dv { color: #40a070; } /* DecVal */
+      code > span.bn { color: #40a070; } /* BaseN */
+      code > span.fl { color: #40a070; } /* Float */
+      code > span.ch { color: #4070a0; } /* Char */
+      code > span.st { color: #4070a0; } /* String */
+      code > span.co { color: #60a0b0; font-style: italic; } /* Comment */
+      code > span.ot { color: #007020; } /* Other */
+      code > span.al { color: #ff0000; font-weight: bold; } /* Alert */
+      code > span.fu { color: #06287e; } /* Function */
+      code > span.er { color: #ff0000; font-weight: bold; } /* Error */
+      code > span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+      code > span.cn { color: #880000; } /* Constant */
+      code > span.sc { color: #4070a0; } /* SpecialChar */
+      code > span.vs { color: #4070a0; } /* VerbatimString */
+      code > span.ss { color: #bb6688; } /* SpecialString */
+      code > span.im { } /* Import */
+      code > span.va { color: #19177c; } /* Variable */
+      code > span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+      code > span.op { color: #666666; } /* Operator */
+      code > span.bu { } /* BuiltIn */
+      code > span.ex { } /* Extension */
+      code > span.pp { color: #bc7a00; } /* Preprocessor */
+      code > span.at { color: #7d9029; } /* Attribute */
+      code > span.do { color: #ba2121; font-style: italic; } /* Documentation */
+      code > span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+      code > span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+      code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+        </style>
+                    <link rel="stylesheet" href="./themes/cyverse/templates/main.css" type="text/css" />
+                    <link rel="icon" href="themes/cyverse/media/favicon.ico" type="image/x-icon">
+        <link rel="stylesheet" href="themes/cyverse/media/css/normalize.min.css">
+        <link rel="stylesheet" href="themes/cyverse/media/css/main.css">
+        <script src="themes/cyverse/media/js/vendor/modernizr-2.8.3-respond-1.4.2.min.js"></script>
+          </head>
+    <body>
+        <!--[if lt IE 8]>
+            <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+        <![endif]-->
+
+                <div class="header-container">
+            <header class="wrapper clearfix">
+                <div class="logo"><img src="themes/cyverse/media/cyverse_logo.png" alt="Staff Guide"></div>
+                <h1 class="title"></h1>
+            </header>
+        </div>
+        
+        <div class="main-container">
+            <div class="main wrapper clearfix">
+              <!-- TABLE OF CONTENTS -->
+                                  <aside>
+                      <h3> TABLE OF CONTENTS </h3>
+                      <ul>
+                      <li><a href="#atmosphere-contribution-guide">Atmosphere Contribution Guide</a><ul>
+                      <li><a href="#overview">Overview</a><ul>
+                      <li><a href="#python-style-guidelines">Python Style Guidelines</a><ul>
+                      <li><a href="#import-ordering">Import ordering</a></li>
+                      </ul></li>
+                      </ul></li>
+                      <li><a href="#ansible-style-guidelines">Ansible Style Guidelines</a></li>
+                      </ul></li>
+                      </ul>
+                  </aside>
+                              <!-- MAIN CONTENT -->
+              <article>
+              <h1 id="atmosphere-contribution-guide">Atmosphere Contribution Guide</h1>
+              <h2 id="overview">Overview</h2>
+              <h3 id="python-style-guidelines">Python Style Guidelines</h3>
+              <ul>
+              <li>Use 4 space indentation</li>
+              <li>Limit lines to 79 characters</li>
+              <li>Remove unused imports</li>
+              <li>Remove trailing whitespace</li>
+              <li>See <a href="https://www.python.org/dev/peps/pep-0008/">PEP8 - Style Guide for Python Code</a></li>
+              </ul>
+              <p>It is recommended that you use the git <code>pre-commit</code> hook to ensure your code is compliant with our style guide.</p>
+              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">ln</span> -s <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/contrib/pre-commit.hook <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/.git/hooks/pre-commit</code></pre></div>
+              <p>To automate running tests before a push use the git <code>pre-push</code> hook to ensure your code passes all the tests.</p>
+              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">ln</span> -s <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/contrib/pre-push.hook <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>.git/hooks/pre-push</code></pre></div>
+              <p>When master is pulled, it’s helpful to know if a <code>pip install</code> or a <code>manage.py migrate</code> is necessary. To get other helpful warnings:</p>
+              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">ln</span> -s <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/contrib/post-merge.hook <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/.git/hooks/post-merge</code></pre></div>
+              <h4 id="import-ordering">Import ordering</h4>
+              <p>Imports should be grouped into the sections below and in sorted order.</p>
+              <ol style="list-style-type: decimal">
+              <li>Standard libraries</li>
+              <li>Third-party libraries</li>
+              <li>External project libraries</li>
+              <li>Local libraries</li>
+              </ol>
+              <h2 id="ansible-style-guidelines">Ansible Style Guidelines</h2>
+              </article>
+            </div> <!-- #main -->
+        </div> <!-- #main-container -->
+
+                <div class="footer-container">
+            <footer class="wrapper">
+                    <footer class="footer"> <!-- Needs to be a `include-after` -->
+          		<div class="container">
+          		  <div class="region region-footer">
+          		    <section id="block-block-25" class="block block-block clearfix">
+          		      <p><img alt="Cyverse" src="./media/cyverse_icon_transp2.png" style="width: 25px; height: 24px;">&nbsp;<a href="http://www.cyverse.org/">CyVerse</a> | <a href="http://www.cyverse.org/open-source">Open Source</a> | <img alt="NSF" src="./media/nsf1.gif" style="width: 25px; height: 25px;">&nbsp;</p>
+          		    </section>
+          		  </div>
+          		</div>
+        	    </footer>
+            </footer>
+        </div>
+        <!-- Included at the end of body -->
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+        <script>window.jQuery || document.write('<script src="themes/cyverse/media/js/vendor/jquery-1.11.2.min.js"><\/script>')</script>
+        
+        <script src="themes/cyverse/media/js/main.js"></script>
+            </body>
+</html>

--- a/dist/contribution_guide.html
+++ b/dist/contribution_guide.html
@@ -72,11 +72,9 @@
                       <h3> TABLE OF CONTENTS </h3>
                       <ul>
                       <li><a href="#atmosphere-contribution-guide">Atmosphere Contribution Guide</a><ul>
-                      <li><a href="#overview">Overview</a><ul>
-                      <li><a href="#general-guidelines">General Guidelines</a></li>
+                      <li><a href="#code-guidelines">Code Guidelines</a><ul>
                       <li><a href="#python-style-guidelines">Python Style Guidelines</a><ul>
                       <li><a href="#import-ordering">Import ordering</a></li>
-                      </ul></li>
                       </ul></li>
                       <li><a href="#ansible-style-guidelines">Ansible Style Guidelines</a><ul>
                       <li><a href="#yaml-files-and-formatting">YAML Files and Formatting</a></li>
@@ -84,24 +82,21 @@
                       <li><a href="#conditional-logic">Conditional Logic</a></li>
                       <li><a href="#modules">Modules</a></li>
                       <li><a href="#files-and-installation-packages">Files and Installation Packages</a></li>
-                      <li><a href="#ansible-security-guidelines">Ansible Security Guidelines</a></li>
-                      <li><a href="#maybe-guidelines-things-to-discuss">Maybe Guidelines? Things to discuss?</a></li>
+                      <li><a href="#possible-ansible-guidelines---things-to-discuss">Possible Ansible Guidelines - Things to Discuss</a></li>
                       </ul></li>
-                      <li><a href="#about-ansible-galaxy-roles">About Ansible Galaxy Roles</a><ul>
-                      <li><a href="#identifying-and-working-with-galaxy-roles">Identifying and Working With Galaxy Roles</a></li>
-                      <li><a href="#installing-consuming-galaxy-roles-in-another-project">Installing (Consuming) Galaxy Roles in Another Project</a></li>
-                      <li><a href="#importing-contributing-a-role-to-galaxy">Importing (Contributing) a Role to Galaxy</a></li>
+                      <li><a href="#ansible-galaxy-roles">Ansible Galaxy Roles</a></li>
                       </ul></li>
+                      <li><a href="#security-guidelines">Security Guidelines</a></li>
+                      <li><a href="#contribution-guide-contribution-guide">Contribution Guide Contribution Guide</a></li>
+                      <li><a href="#further-reading">Further Reading</a></li>
                       </ul></li>
                       </ul>
                   </aside>
                               <!-- MAIN CONTENT -->
               <article>
               <h1 id="atmosphere-contribution-guide">Atmosphere Contribution Guide</h1>
-              <h2 id="overview">Overview</h2>
-              <p>These guidelines will improve the consistency and comprehensibility of our code.</p>
-              <p>New contributions to “the Atmosphere projects” (atmosphere, troposphere, atmosphere-ansible, clank, etc) are generally expected to follow these guidelines, and future pull requests will be checked for adherence.</p>
-              <h3 id="general-guidelines">General Guidelines</h3>
+              <h2 id="code-guidelines">Code Guidelines</h2>
+              <p>These guidelines will improve the consistency and comprehensibility of our code. Contributions to “the Atmosphere projects” (atmosphere, troposphere, atmosphere-ansible, clank, etc) will be checked for adherence.</p>
               <ul>
               <li><a href="https://late.am/post/2016/04/28/delete-your-dead-code.html">Delete your dead code</a>. If you know that code is not run, don’t comment it out, instead remove it completely. Old code remains in version control and we can dig into the past if needed.</li>
               </ul>
@@ -127,51 +122,97 @@
               <li>External project libraries</li>
               <li>Local libraries</li>
               </ol>
-              <h2 id="ansible-style-guidelines">Ansible Style Guidelines</h2>
-              <p>These apply to repos like clank and atmosphere-ansible (collectively, “the Ansible projects”). Some are borrowed from <a href="https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions">Open edX Operations</a> and <a href="http://docs.openstack.org/developer/openstack-ansible/developer-docs/contribute.html">OpenStack-Ansible</a>.</p>
-              <h3 id="yaml-files-and-formatting">YAML Files and Formatting</h3>
-              <p>YAML files should: - Have a name ending in <code>.yml</code> - Begin with three dashes followed by a blank line - Use 2-space indents - Use YAML dictionary format ratner than in-line module arguments. So, this: <code>- name: foo     file:       src: /tmp/bar       dest: /tmp/baz       state: present</code> Not this: <code>- name: foo src=/tmp/bar dest=/tmp/baz state=present</code> - Use YAML <a href="http://yaml.org/spec/1.2/spec.html#id2796251">folded style</a> for long lines: <code>- shell: &gt;             python a very long command --with=very --long-options=foo             --and-even=more_options --like-these</code></p>
-              <h3 id="variables">Variables</h3>
+              <h3 id="ansible-style-guidelines">Ansible Style Guidelines</h3>
+              <p>These apply to repos such as clank and atmosphere-ansible (collectively, “the Ansible projects”). Some are borrowed from <a href="https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions">Open edX Operations</a> and <a href="http://docs.openstack.org/developer/openstack-ansible/developer-docs/contribute.html">OpenStack-Ansible</a>.</p>
+              <h4 id="yaml-files-and-formatting">YAML Files and Formatting</h4>
+              <p>YAML files should:</p>
+              <ul>
+              <li>Have a name ending in <code>.yml</code></li>
+              <li>Begin with three dashes followed by a blank line</li>
+              <li>Use 2-space indents</li>
+              <li>Use YAML dictionary format ratner than in-line module arguments. So, this:</li>
+              </ul>
+              <pre><code>- name: foo
+                file:
+                  src: /tmp/bar
+                  dest: /tmp/baz
+                  state: present</code></pre>
+              <p>Not this:</p>
+              <pre><code>- name: foo src=/tmp/bar dest=/tmp/baz state=present</code></pre>
+              <ul>
+              <li>Use YAML <a href="http://yaml.org/spec/1.2/spec.html#id2796251">folded style</a> for long lines:</li>
+              </ul>
+              <pre><code>- shell: &gt;
+                      python a very long command --with=very --long-options=foo
+                      --and-even=more_options --like-these</code></pre>
+              <h4 id="variables">Variables</h4>
               <ul>
               <li>Use spaces between double-braces and variable names: <code>{{ var }}</code> instead of <code>{{var}}</code></li>
-              <li>Bare variables in YAML must be quoted, e.g. ```</li>
-              <li>foo: “{{ bar }}” ```</li>
-              <li><p>For variables that have some default and are optionally overridden by a consumer/deployer: define the variable’s default value in the role <code>defaults/</code> instead of using the <code>| default()</code> jinja2 filter. This keeps configuration separate from code.</p></li>
-              <li><p>Prefix task names with the role name?</p></li>
+              <li>Bare variables in YAML must be quoted, e.g.</li>
               </ul>
-              <h3 id="conditional-logic">Conditional Logic</h3>
+              <pre><code>- foo: &quot;{{ bar }}&quot;</code></pre>
               <ul>
-              <li>To conditionally include or exclude a role, use the following syntax in a playbook: <code>roles: - { role: ldap, when: CONFIGURE_LDAP == true }</code> Avoid applying the same tag to every task in a role and expecting a user to skip a role with <code>--skip-tags</code>.</li>
+              <li>For variables that have some default and are optionally overridden by a consumer/deployer: define the variable’s default value in the role <code>defaults/</code> instead of using the <code>| default()</code> jinja2 filter. This keeps configuration separate from code.</li>
               </ul>
-              <h3 id="modules">Modules</h3>
+              <h5 id="distro-specific-variables">Distro-Specific Variables</h5>
+              <p>Many roles must take <em>differently-configured</em> actions to effect the same result, depending on the target’s operating system. Accomplish this configuration by defining your variables in files like so:</p>
+              <pre><code>vars/
+              ├── CentOS-5.yml
+              ├── CentOS.yml
+              ├── Ubuntu-12.yml
+              ├── Ubuntu-16.yml
+              └── Ubuntu.yml</code></pre>
+              <p>Use the following task to include the appropriate variables file:</p>
+              <pre><code>- name: gather OS-specific variables
+                include_vars: &quot;{{ item }}&quot;
+                with_first_found:
+                  - &quot;{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml&quot;
+                  - &quot;{{ ansible_distribution }}.yml&quot;</code></pre>
+              <p>Matching is most-specific to least-specific, so with the above example, a role targeting an Ubuntu 16.04 system would include the variables defined in Ubuntu-16.yml, while a role targeting Ubuntu 14.04 would include the variables defined in Ubuntu.yml. Also, only one file will match and there is no concept of inheritance (so usually, the same variables should be defined in each file).</p>
+              <p>Role-specific variables that do not vary per-distro can still be defined in <code>vars/main.yml</code> or <code>defaults/main.yml</code>.</p>
+              <h4 id="conditional-logic">Conditional Logic</h4>
+              <ul>
+              <li>To conditionally include or exclude a role, use the following syntax in a playbook:</li>
+              </ul>
+              <p><code>roles:     - { role: ldap, when: CONFIGURE_LDAP == true }</code></p>
+              <p>Avoid applying the same tag to every task in a role and expecting a user to skip a role with <code>--skip-tags</code>.</p>
+              <h4 id="modules">Modules</h4>
               <ul>
               <li>Use <code>command</code> rather than <code>shell</code> unless shell is explicitly required (<a href="http://docs.ansible.com/ansible/shell_module.html#notes">source 0</a> <a href="https://blog.confirm.ch/ansible-modules-shell-vs-command/">source 1</a>).</li>
               </ul>
-              <h3 id="files-and-installation-packages">Files and Installation Packages</h3>
+              <h4 id="files-and-installation-packages">Files and Installation Packages</h4>
               <p>Avoid storing large binary files or installation packages in Ansible projects / version control. Instead, host it externally (e.g. CyVerse’s S3 account) and download from there, or download from the publisher.</p>
-              <h3 id="ansible-security-guidelines">Ansible Security Guidelines</h3>
-              <p>Do not store anything secret or sensitive (e.g. passwords, SSH private keys, license keys) in public version control. Any secrets stored in private version control should be encrypted with Ansible Vault, and Vault passphrases should not be stored in plaintext.</p>
-              <p>Any installation packages should be downloaded in a secure way that prevents man-in-the-middle attacks from changing the contents (e.g. HTTPS, or APT packages signed with a GPG key).</p>
-              <p>Avoid disabling SSH host key checking.</p>
-              <h3 id="maybe-guidelines-things-to-discuss">Maybe Guidelines? Things to discuss?</h3>
+              <h4 id="possible-ansible-guidelines---things-to-discuss">Possible Ansible Guidelines - Things to Discuss</h4>
               <ul>
-              <li><p>Variables that are internal to a role should be in lowercase? Variables that are environment-specific and should be overridden in UPPERCASE?</p></li>
-              <li><p>Prefix all variables defined in a role with the name of the role? Since Ansible doesn’t really have variable scoping?</p></li>
-              <li><p>Separate words in role names with dashes (<code>my-role</code>)?</p></li>
+              <li>Variables that are internal to a role should be in lowercase? Variables that are environment-specific and should be overridden in UPPERCASE?</li>
+              <li>When to use a role’s <code>vars/</code> vs. <code>defaults/</code> directory? <code>vars/</code> for things internal to the role (e.g. distro-specific), <code>defaults/</code> for things expected to be overridden by a consumer?</li>
+              <li>Prefix all variables defined in a role with the name of the role to avoid collisions?</li>
+              <li>Prefix task names with the role name, to ease human parsing of log output?</li>
+              <li>Separate words in role names with dashes (<code>my-role</code>)?</li>
               </ul>
-              <h2 id="about-ansible-galaxy-roles">About Ansible Galaxy Roles</h2>
+              <h3 id="ansible-galaxy-roles">Ansible Galaxy Roles</h3>
               <p>The Ansible projects will use similar code to perform very similar tasks, so there is an effort to structure our code into modular, re-usable roles. These roles are generally hosted in the <a href="https://github.com/cyverse-ansible">CyVerse-Ansible</a> organization and consumed via <a href="https://galaxy.ansible.com/">Ansible Galaxy</a>. This will centralize the development/maintenance effort and provide easy consumption by any interested groups. New Ansible contributors are encouraged to read <a href="https://galaxy.ansible.com/intro">Ansible Galaxy Intro</a>.</p>
-              <h4 id="identifying-and-working-with-galaxy-roles">Identifying and Working With Galaxy Roles</h4>
+              <h5 id="identifying-and-working-with-galaxy-roles">Identifying and Working With Galaxy Roles</h5>
               <p>The Ansible projects include a mix of roles installed from Galaxy and roles defined locally. The following clues should indicate that a given role was installed from Galaxy.</p>
               <ul>
               <li>The role is defined in the project’s <code>requirements.yml</code></li>
               <li>The role contains <code>meta/galaxy_install_info</code> and <code>meta/main.yml</code></li>
               </ul>
               <p>There is a clear concept of “upstream” (roles) and “downstream” (projects that consume them), so generally we should <em>avoid making persistent changes</em> to a role which has been installed from Galaxy <em>inside a repository that consumes it</em>. Such changes will 1. not propagate back upstream to the role repository, and 2. be overwritten the next time the role is updated from Galaxy. Instead, make your changes in the upstream Ansible role (see below), re-import it, and install the new version in the consuming repository.</p>
-              <h4 id="installing-consuming-galaxy-roles-in-another-project">Installing (Consuming) Galaxy Roles in Another Project</h4>
+              <h5 id="installing-consuming-galaxy-roles-in-another-project">Installing (Consuming) Galaxy Roles in Another Project</h5>
               <p>The Ansible projects use a <code>requirements.yml</code> file to define the Galaxy roles we are consuming. Install new roles and update existing roles in a repo by running <code>ansible-galaxy install -f -r requirements.yml -p roles/</code> from the <code>ansible</code> folder. Then, the desired roles will be copied into your project, and you can call them from Playbooks like any other role.</p>
-              <h4 id="importing-contributing-a-role-to-galaxy">Importing (Contributing) a Role to Galaxy</h4>
+              <h5 id="importing-contributing-a-role-to-galaxy">Importing (Contributing) a Role to Galaxy</h5>
               <p>Follow the instructions in <a href="https://github.com/CyVerse-Ansible/ansible-role-template">this template</a> to publish an Ansible role to Galaxy and set up automated testing with Travis CI; then you can install the role into other projects.</p>
+              <h2 id="security-guidelines">Security Guidelines</h2>
+              <p>Do not store anything secret or sensitive (e.g. passphrases, SSH private keys, license keys) in public version control. Environment-specific secrets can be encrypted with Ansible Vault and stored in private version control.</p>
+              <p>Any REST API calls that handle privileged/sensitive information (or access to private resources) should use HTTPS endpoints. Also, any downloaded code that will be executed in a trusted context (e.g. scripts and installation packages) should be obtained in a way that verifies the other party’s authenticity and prevents man-in-the-middle attacks from changing the contents. In practical terms, use HTTPS, or APT packages signed with a GPG key. Avoid disabling SSL certificate verification for any of the above.</p>
+              <p>Avoid disabling SSH host key checking. When possible, learn a server’s SSH host key out-of-band and verify it on first connection.</p>
+              <h2 id="contribution-guide-contribution-guide">Contribution Guide Contribution Guide</h2>
+              <p>If you ask someone not to do something, offer a reasonable alternative approach. Otherwise, they may ignore your advice for the sake of pragmatism.</p>
+              <h2 id="further-reading">Further Reading</h2>
+              <ul>
+              <li><a href="http://wiki.c2.com/?CodeSmell">Code Smells</a></li>
+              </ul>
               </article>
             </div> <!-- #main -->
         </div> <!-- #main-container -->

--- a/dist/contribution_guide.html
+++ b/dist/contribution_guide.html
@@ -87,7 +87,7 @@
                       <li><a href="#contribution-guide-contribution-guide">Contribution Guide Contribution Guide</a></li>
                       <li><a href="#further-reading">Further Reading</a></li>
                       </ul></li>
-                      <li><a href="#python">Python</a><ul>
+                      <li><a href="#python-style-guidelines">Python Style Guidelines</a><ul>
                       <li><a href="#naming">Naming</a><ul>
                       <li><a href="#general-naming-guidelines">General Naming Guidelines</a></li>
                       </ul></li>
@@ -206,7 +206,7 @@
               <ul>
               <li><a href="http://wiki.c2.com/?CodeSmell">Code Smells</a></li>
               </ul>
-              <h1 id="python">Python</h1>
+              <h1 id="python-style-guidelines">Python Style Guidelines</h1>
               <p>This Python style guide is largely copied from <a href="http://cosdev.readthedocs.io/en/latest/style_guides/python.html">Center for Open Science</a></p>
               <p>Follow <a href="http://www.python.org/dev/peps/pep-0008/">PEP8</a>, when sensible.</p>
               <h2 id="naming">Naming</h2>

--- a/dist/index.html
+++ b/dist/index.html
@@ -49,6 +49,7 @@
               <li><a href="./staff_guide.html">Staff Guide</a></li>
               <li><a href="./user_guide.html">User Guide</a></li>
               <li><a href="./imaging_guide.html">Imaging Guide</a></li>
+              <li><a href="./contribution_guide.html">Atmosphere Contribution Guide</a></li>
               </ul>
               </article>
             </div> <!-- #main -->

--- a/src/connecting_cloud_provider/connecting_cloud_provider.md
+++ b/src/connecting_cloud_provider/connecting_cloud_provider.md
@@ -1,3 +1,5 @@
+# Connecting a Cloud Provider to Atmosphere
+
 ## Overview
 This guide will help you connect Atmosphere to an OpenStack cloud. Atmosphere connects to OpenStack APIs using both LibCloud and the OpenStack client tools.
 

--- a/src/contribution_guide/contribution_guide.md
+++ b/src/contribution_guide/contribution_guide.md
@@ -6,10 +6,6 @@ These guidelines will improve the consistency and comprehensibility of our code.
 
 - [Delete your dead code](https://late.am/post/2016/04/28/delete-your-dead-code.html). If you know that code is not run, don't comment it out, instead remove it completely. Old code remains in version control and we can dig into the past if needed.
 
-### Python Style Guidelines
-
-See [Python](python.html)
-
 ### Ansible Style Guidelines
 
 These apply to repos such as clank and atmosphere-ansible (collectively, "the Ansible projects"). Some are borrowed from [Open edX Operations](https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions) and [OpenStack-Ansible](http://docs.openstack.org/developer/openstack-ansible/developer-docs/contribute.html).

--- a/src/contribution_guide/contribution_guide.md
+++ b/src/contribution_guide/contribution_guide.md
@@ -8,41 +8,7 @@ These guidelines will improve the consistency and comprehensibility of our code.
 
 ### Python Style Guidelines
 
-- Use 4 space indentation
-- Limit lines to 79 characters
-- Remove unused imports
-- Remove trailing whitespace
-- See [PEP8 - Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/)
-
-It is recommended that you use the git `pre-commit` hook to ensure your code
-is compliant with our style guide.
-
-```bash
-ln -s $(pwd)/contrib/pre-commit.hook $(pwd)/.git/hooks/pre-commit
-```
-
-To automate running tests before a push use the git `pre-push` hook to ensure
-your code passes all the tests.
-
-```bash
-ln -s $(pwd)/contrib/pre-push.hook $(pwd).git/hooks/pre-push
-```
-
-When master is pulled, it's helpful to know if a `pip install` or a `manage.py
-migrate` is necessary. To get other helpful warnings:
-
-```bash
-ln -s $(pwd)/contrib/post-merge.hook $(pwd)/.git/hooks/post-merge
-```
-
-#### Import ordering
-
-Imports should be grouped into the sections below and in sorted order.
-
-1. Standard libraries
-2. Third-party libraries
-3. External project libraries
-4. Local libraries
+See [Python](python.html)
 
 ### Ansible Style Guidelines
 

--- a/src/contribution_guide/contribution_guide.md
+++ b/src/contribution_guide/contribution_guide.md
@@ -105,7 +105,7 @@ Avoid storing large binary files or installation packages in Ansible projects / 
 
 #### Possible Ansible Guidelines - Things to Discuss
 
-- [Quote all strings and prefer single quotes over double quotes](https://github.com/whitecloud/ansible-styleguide#quotes)?
+- [Quote all strings and prefer single quotes over double quotes](https://github.com/whitecloud/ansible-styleguide#quotes)? This makes clear what is a string and what refers to a variable
 - Define a [general order for a task declaration](https://github.com/whitecloud/ansible-styleguide#task-declaration)?
 - Variables that are internal to a role should be in snake_case? Variables that are environment-specific and should be overridden in UPPERCASE?
 - When to use a role's `vars/` vs. `defaults/` directory? `vars/` for things internal to the role (e.g. distro-specific), `defaults/` for things expected to be overridden by a consumer?

--- a/src/contribution_guide/contribution_guide.md
+++ b/src/contribution_guide/contribution_guide.md
@@ -1,0 +1,42 @@
+# Atmosphere Contribution Guide
+
+## Overview
+
+### Python Style Guidelines
+
+- Use 4 space indentation
+- Limit lines to 79 characters
+- Remove unused imports
+- Remove trailing whitespace
+- See [PEP8 - Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/)
+
+It is recommended that you use the git `pre-commit` hook to ensure your code
+is compliant with our style guide.
+
+```bash
+ln -s $(pwd)/contrib/pre-commit.hook $(pwd)/.git/hooks/pre-commit
+```
+
+To automate running tests before a push use the git `pre-push` hook to ensure
+your code passes all the tests.
+
+```bash
+ln -s $(pwd)/contrib/pre-push.hook $(pwd).git/hooks/pre-push
+```
+
+When master is pulled, it's helpful to know if a `pip install` or a `manage.py
+migrate` is necessary. To get other helpful warnings:
+
+```bash
+ln -s $(pwd)/contrib/post-merge.hook $(pwd)/.git/hooks/post-merge
+```
+
+#### Import ordering
+Imports should be grouped into the sections below and in sorted order.
+
+1. Standard libraries
+2. Third-party libraries
+3. External project libraries
+4. Local libraries
+
+## Ansible Style Guidelines

--- a/src/contribution_guide/contribution_guide.md
+++ b/src/contribution_guide/contribution_guide.md
@@ -17,7 +17,7 @@ YAML files should:
 - Have a name ending in `.yml`
 - Begin with three dashes followed by a blank line
 - Use 2-space indents
-- Use YAML dictionary format rather than in-line module arguments. So, this:
+- Use YAML dictionary format rather than in-line `key=value`s. It's easier to read and reduces changeset collisions in version control. So, do this:
 
 ```
 - name: foo
@@ -45,6 +45,7 @@ Not this:
 #### Variables
 
 - Use spaces between double-braces and variable names: `{{ var }}` instead of `{{var}}`
+- For boolean variables, use un-quoted `true` and `false`
 - Bare variables in YAML must be quoted, e.g.
 
 ```
@@ -80,6 +81,10 @@ Matching is most-specific to least-specific, so with the above example, a role t
 
 Role-specific variables that do not vary per-distro can still be defined in `vars/main.yml` or `defaults/main.yml`.
 
+#### Tasks
+
+Name your tasks to reflect the completed action in the past tense: `denyhosts stopped and disabled` rather than `stop and disable denyhosts`. This reinforces the goal of defining a series of idempotent steps to either reach or confirm a desired end state.
+
 #### Conditional Logic
 - To conditionally include or exclude a role, use the following syntax in a playbook:
 
@@ -100,7 +105,9 @@ Avoid storing large binary files or installation packages in Ansible projects / 
 
 #### Possible Ansible Guidelines - Things to Discuss
 
-- Variables that are internal to a role should be in lowercase? Variables that are environment-specific and should be overridden in UPPERCASE?
+- [Quote all strings and prefer single quotes over double quotes](https://github.com/whitecloud/ansible-styleguide#quotes)?
+- Define a [general order for a task declaration](https://github.com/whitecloud/ansible-styleguide#task-declaration)?
+- Variables that are internal to a role should be in snake_case? Variables that are environment-specific and should be overridden in UPPERCASE?
 - When to use a role's `vars/` vs. `defaults/` directory? `vars/` for things internal to the role (e.g. distro-specific), `defaults/` for things expected to be overridden by a consumer?
 - Prefix all variables defined in a role with the name of the role to avoid collisions?
 - Prefix task names with the role name, to ease human parsing of log output?

--- a/src/contribution_guide/contribution_guide.md
+++ b/src/contribution_guide/contribution_guide.md
@@ -55,7 +55,7 @@ YAML files should:
 - Have a name ending in `.yml`
 - Begin with three dashes followed by a blank line
 - Use 2-space indents
-- Use YAML dictionary format ratner than in-line module arguments. So, this:
+- Use YAML dictionary format rather than in-line module arguments. So, this:
 
 ```
 - name: foo

--- a/src/contribution_guide/contribution_guide.md
+++ b/src/contribution_guide/contribution_guide.md
@@ -47,12 +47,71 @@ Imports should be grouped into the sections below and in sorted order.
 
 ## Ansible Style Guidelines
 
-These apply to repos like clank and atmosphere-ansible (collectively, "the Ansible projects").
+These apply to repos like clank and atmosphere-ansible (collectively, "the Ansible projects"). Some are borrowed from [Open edX Operations](https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions) and [OpenStack-Ansible](http://docs.openstack.org/developer/openstack-ansible/developer-docs/contribute.html).
 
-### Optionally Defined Variables
-Instead of using the `| default()`
+### YAML Files and Formatting
+YAML files should:
+- Have a name ending in `.yml`
+- Begin with three dashes followed by a blank line
+- Use 2-space indents
+- Use YAML dictionary format ratner than in-line module arguments. So, this:
+  ```
+  - name: foo
+    file:
+      src: /tmp/bar
+      dest: /tmp/baz
+      state: present
+  ```
+  Not this:
+  ```
+  - name: foo src=/tmp/bar dest=/tmp/baz state=present
+  ```
+- Use YAML [folded style](http://yaml.org/spec/1.2/spec.html#id2796251) for long lines:
+  ```
+  - shell: >
+         	python a very long command --with=very --long-options=foo
+         	--and-even=more_options --like-these
+  ```
 
-### Ansible Galaxy Roles
+### Variables
+- Use spaces between double-braces and variable names: `{{ var }}` instead of `{{var}}`
+- Bare variables in YAML must be quoted, e.g.
+  ```
+  - foo: "{{ bar }}"
+  ```
+- For variables that have some default and are optionally overridden by a consumer/deployer: define the variable's default value in the role `defaults/` instead of using the `| default()` jinja2 filter. This keeps configuration separate from code.
+
+- Prefix task names with the role name?
+
+### Conditional Logic
+- To conditionally include or exclude a role, use the following syntax in a playbook:
+  ```
+    roles:
+    - { role: ldap, when: CONFIGURE_LDAP == true }
+  ```
+  Avoid applying the same tag to every task in a role and expecting a user to skip a role with `--skip-tags`.
+
+### Modules
+- Use `command` rather than `shell` unless shell is explicitly required ([source 0](http://docs.ansible.com/ansible/shell_module.html#notes) [source 1](https://blog.confirm.ch/ansible-modules-shell-vs-command/)).
+
+### Files and Installation Packages
+Avoid storing large binary files or installation packages in Ansible projects / version control. Instead, host it externally (e.g. CyVerse's S3 account) and download from there, or download from the publisher.
+
+### Ansible Security Guidelines
+Do not store anything secret or sensitive (e.g. passwords, SSH private keys, license keys) in public version control. Any secrets stored in private version control should be encrypted with Ansible Vault, and Vault passphrases should not be stored in plaintext.
+
+Any installation packages should be downloaded in a secure way that prevents man-in-the-middle attacks from changing the contents (e.g. HTTPS, or APT packages signed with a GPG key).
+
+Avoid disabling SSH host key checking.
+
+### Maybe Guidelines? Things to discuss?
+- Variables that are internal to a role should be in lowercase? Variables that are environment-specific and should be overridden in UPPERCASE?
+
+- Prefix all variables defined in a role with the name of the role? Since Ansible doesn't really have variable scoping?
+
+- Separate words in role names with dashes (`my-role`)?
+
+## About Ansible Galaxy Roles
 
 The Ansible projects will use similar code to perform very similar tasks, so there is an effort to structure our code into modular, re-usable roles. These roles are generally hosted in the [CyVerse-Ansible](https://github.com/cyverse-ansible) organization and consumed via [Ansible Galaxy](https://galaxy.ansible.com/). This will centralize the development/maintenance effort and provide easy consumption by any interested groups. New Ansible contributors are encouraged to read [Ansible Galaxy Intro](https://galaxy.ansible.com/intro).
 

--- a/src/contribution_guide/contribution_guide.md
+++ b/src/contribution_guide/contribution_guide.md
@@ -1,11 +1,9 @@
 # Atmosphere Contribution Guide
 
-## Overview
-These guidelines will improve the consistency and comprehensibility of our code.
+## Code Guidelines
 
-New contributions to "the Atmosphere projects" (atmosphere, troposphere, atmosphere-ansible, clank, etc) are generally expected to follow these guidelines, and future pull requests will be checked for adherence.
+These guidelines will improve the consistency and comprehensibility of our code. Contributions to "the Atmosphere projects" (atmosphere, troposphere, atmosphere-ansible, clank, etc) will be checked for adherence.
 
-### General Guidelines
 - [Delete your dead code](https://late.am/post/2016/04/28/delete-your-dead-code.html). If you know that code is not run, don't comment it out, instead remove it completely. Old code remains in version control and we can dig into the past if needed.
 
 ### Python Style Guidelines
@@ -38,6 +36,7 @@ ln -s $(pwd)/contrib/post-merge.hook $(pwd)/.git/hooks/post-merge
 ```
 
 #### Import ordering
+
 Imports should be grouped into the sections below and in sorted order.
 
 1. Standard libraries
@@ -45,77 +44,110 @@ Imports should be grouped into the sections below and in sorted order.
 3. External project libraries
 4. Local libraries
 
-## Ansible Style Guidelines
+### Ansible Style Guidelines
 
-These apply to repos like clank and atmosphere-ansible (collectively, "the Ansible projects"). Some are borrowed from [Open edX Operations](https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions) and [OpenStack-Ansible](http://docs.openstack.org/developer/openstack-ansible/developer-docs/contribute.html).
+These apply to repos such as clank and atmosphere-ansible (collectively, "the Ansible projects"). Some are borrowed from [Open edX Operations](https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions) and [OpenStack-Ansible](http://docs.openstack.org/developer/openstack-ansible/developer-docs/contribute.html).
 
-### YAML Files and Formatting
+#### YAML Files and Formatting
+
 YAML files should:
+
 - Have a name ending in `.yml`
 - Begin with three dashes followed by a blank line
 - Use 2-space indents
 - Use YAML dictionary format ratner than in-line module arguments. So, this:
-  ```
-  - name: foo
-    file:
-      src: /tmp/bar
-      dest: /tmp/baz
-      state: present
-  ```
-  Not this:
-  ```
-  - name: foo src=/tmp/bar dest=/tmp/baz state=present
-  ```
-- Use YAML [folded style](http://yaml.org/spec/1.2/spec.html#id2796251) for long lines:
-  ```
-  - shell: >
-         	python a very long command --with=very --long-options=foo
-         	--and-even=more_options --like-these
-  ```
 
-### Variables
+```
+- name: foo
+  file:
+    src: /tmp/bar
+    dest: /tmp/baz
+    state: present
+```
+
+Not this:
+
+```
+- name: foo src=/tmp/bar dest=/tmp/baz state=present
+```
+
+- Use YAML [folded style](http://yaml.org/spec/1.2/spec.html#id2796251) for long lines:
+
+```
+- shell: >
+       	python a very long command --with=very --long-options=foo
+       	--and-even=more_options --like-these
+```
+
+#### Variables
+
 - Use spaces between double-braces and variable names: `{{ var }}` instead of `{{var}}`
 - Bare variables in YAML must be quoted, e.g.
-  ```
-  - foo: "{{ bar }}"
-  ```
+
+```
+- foo: "{{ bar }}"
+```
+
 - For variables that have some default and are optionally overridden by a consumer/deployer: define the variable's default value in the role `defaults/` instead of using the `| default()` jinja2 filter. This keeps configuration separate from code.
 
-- Prefix task names with the role name?
+##### Distro-Specific Variables
 
-### Conditional Logic
+Many roles must take *differently-configured* actions to effect the same result, depending on the target's operating system. Accomplish this configuration by defining your variables in files like so:
+
+```
+vars/
+├── CentOS-5.yml
+├── CentOS.yml
+├── Ubuntu-12.yml
+├── Ubuntu-16.yml
+└── Ubuntu.yml
+```
+
+Use the following task to include the appropriate variables file:
+
+```
+- name: gather OS-specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_distribution }}.yml"
+```
+
+Matching is most-specific to least-specific, so with the above example, a role targeting an Ubuntu 16.04 system would include the variables defined in Ubuntu-16.yml, while a role targeting Ubuntu 14.04 would include the variables defined in Ubuntu.yml. Also, only one file will match and there is no concept of inheritance (so usually, the same variables should be defined in each file).
+
+Role-specific variables that do not vary per-distro can still be defined in `vars/main.yml` or `defaults/main.yml`.
+
+#### Conditional Logic
 - To conditionally include or exclude a role, use the following syntax in a playbook:
+
   ```
     roles:
     - { role: ldap, when: CONFIGURE_LDAP == true }
   ```
+
   Avoid applying the same tag to every task in a role and expecting a user to skip a role with `--skip-tags`.
 
-### Modules
+#### Modules
+
 - Use `command` rather than `shell` unless shell is explicitly required ([source 0](http://docs.ansible.com/ansible/shell_module.html#notes) [source 1](https://blog.confirm.ch/ansible-modules-shell-vs-command/)).
 
-### Files and Installation Packages
+#### Files and Installation Packages
+
 Avoid storing large binary files or installation packages in Ansible projects / version control. Instead, host it externally (e.g. CyVerse's S3 account) and download from there, or download from the publisher.
 
-### Ansible Security Guidelines
-Do not store anything secret or sensitive (e.g. passwords, SSH private keys, license keys) in public version control. Any secrets stored in private version control should be encrypted with Ansible Vault, and Vault passphrases should not be stored in plaintext.
+#### Possible Ansible Guidelines - Things to Discuss
 
-Any installation packages should be downloaded in a secure way that prevents man-in-the-middle attacks from changing the contents (e.g. HTTPS, or APT packages signed with a GPG key).
-
-Avoid disabling SSH host key checking.
-
-### Maybe Guidelines? Things to discuss?
 - Variables that are internal to a role should be in lowercase? Variables that are environment-specific and should be overridden in UPPERCASE?
-
-- Prefix all variables defined in a role with the name of the role? Since Ansible doesn't really have variable scoping?
-
+- When to use a role's `vars/` vs. `defaults/` directory? `vars/` for things internal to the role (e.g. distro-specific), `defaults/` for things expected to be overridden by a consumer?
+- Prefix all variables defined in a role with the name of the role to avoid collisions?
+- Prefix task names with the role name, to ease human parsing of log output?
 - Separate words in role names with dashes (`my-role`)?
 
-## About Ansible Galaxy Roles
+### Ansible Galaxy Roles
 
 The Ansible projects will use similar code to perform very similar tasks, so there is an effort to structure our code into modular, re-usable roles. These roles are generally hosted in the [CyVerse-Ansible](https://github.com/cyverse-ansible) organization and consumed via [Ansible Galaxy](https://galaxy.ansible.com/). This will centralize the development/maintenance effort and provide easy consumption by any interested groups. New Ansible contributors are encouraged to read [Ansible Galaxy Intro](https://galaxy.ansible.com/intro).
 
-#### Identifying and Working With Galaxy Roles
+##### Identifying and Working With Galaxy Roles
 
 The Ansible projects include a mix of roles installed from Galaxy and roles defined locally. The following clues should indicate that a given role was installed from Galaxy.
 
@@ -124,10 +156,26 @@ The Ansible projects include a mix of roles installed from Galaxy and roles defi
 
 There is a clear concept of "upstream" (roles) and "downstream" (projects that consume them), so generally we should *avoid making persistent changes* to a role which has been installed from Galaxy *inside a repository that consumes it*. Such changes will 1. not propagate back upstream to the role repository, and 2. be overwritten the next time the role is updated from Galaxy. Instead, make your changes in the upstream Ansible role (see below), re-import it, and install the new version in the consuming repository.
 
-#### Installing (Consuming) Galaxy Roles in Another Project
+##### Installing (Consuming) Galaxy Roles in Another Project
 
 The Ansible projects use a `requirements.yml` file to define the Galaxy roles we are consuming. Install new roles and update existing roles in a repo by running `ansible-galaxy install -f -r requirements.yml -p roles/` from the `ansible` folder. Then, the desired roles will be copied into your project, and you can call them from Playbooks like any other role.
 
-#### Importing (Contributing) a Role to Galaxy
+##### Importing (Contributing) a Role to Galaxy
 
 Follow the instructions in [this template](https://github.com/CyVerse-Ansible/ansible-role-template) to publish an Ansible role to Galaxy and set up automated testing with Travis CI; then you can install the role into other projects.
+
+## Security Guidelines
+
+Do not store anything secret or sensitive (e.g. passphrases, SSH private keys, license keys) in public version control. Environment-specific secrets can be encrypted with Ansible Vault and stored in private version control.
+
+Any REST API calls that handle privileged/sensitive information (or access to private resources) should use HTTPS endpoints. Also, any downloaded code that will be executed in a trusted context (e.g. scripts and installation packages) should be obtained in a way that verifies the other party's authenticity and prevents man-in-the-middle attacks from changing the contents. In practical terms, use HTTPS, or APT packages signed with a GPG key. Avoid disabling SSL certificate verification for any of the above.
+
+Avoid disabling SSH host key checking. When possible, learn a server's SSH host key out-of-band and verify it on first connection.
+
+## Contribution Guide Contribution Guide
+
+If you ask someone not to do something, offer a reasonable alternative approach. Otherwise, they may ignore your advice for the sake of pragmatism.
+
+## Further Reading
+
+- [Code Smells](http://wiki.c2.com/?CodeSmell)

--- a/src/contribution_guide/contribution_guide.md
+++ b/src/contribution_guide/contribution_guide.md
@@ -1,6 +1,12 @@
 # Atmosphere Contribution Guide
 
 ## Overview
+These guidelines will improve the consistency and comprehensibility of our code.
+
+New contributions to "the Atmosphere projects" (atmosphere, troposphere, atmosphere-ansible, clank, etc) are generally expected to follow these guidelines, and future pull requests will be checked for adherence.
+
+### General Guidelines
+- [Delete your dead code](https://late.am/post/2016/04/28/delete-your-dead-code.html). If you know that code is not run, don't comment it out, instead remove it completely. Old code remains in version control and we can dig into the past if needed.
 
 ### Python Style Guidelines
 
@@ -40,3 +46,29 @@ Imports should be grouped into the sections below and in sorted order.
 4. Local libraries
 
 ## Ansible Style Guidelines
+
+These apply to repos like clank and atmosphere-ansible (collectively, "the Ansible projects").
+
+### Optionally Defined Variables
+Instead of using the `| default()`
+
+### Ansible Galaxy Roles
+
+The Ansible projects will use similar code to perform very similar tasks, so there is an effort to structure our code into modular, re-usable roles. These roles are generally hosted in the [CyVerse-Ansible](https://github.com/cyverse-ansible) organization and consumed via [Ansible Galaxy](https://galaxy.ansible.com/). This will centralize the development/maintenance effort and provide easy consumption by any interested groups. New Ansible contributors are encouraged to read [Ansible Galaxy Intro](https://galaxy.ansible.com/intro).
+
+#### Identifying and Working With Galaxy Roles
+
+The Ansible projects include a mix of roles installed from Galaxy and roles defined locally. The following clues should indicate that a given role was installed from Galaxy.
+
+- The role is defined in the project's `requirements.yml`
+- The role contains `meta/galaxy_install_info` and `meta/main.yml`
+
+There is a clear concept of "upstream" (roles) and "downstream" (projects that consume them), so generally we should *avoid making persistent changes* to a role which has been installed from Galaxy *inside a repository that consumes it*. Such changes will 1. not propagate back upstream to the role repository, and 2. be overwritten the next time the role is updated from Galaxy. Instead, make your changes in the upstream Ansible role (see below), re-import it, and install the new version in the consuming repository.
+
+#### Installing (Consuming) Galaxy Roles in Another Project
+
+The Ansible projects use a `requirements.yml` file to define the Galaxy roles we are consuming. Install new roles and update existing roles in a repo by running `ansible-galaxy install -f -r requirements.yml -p roles/` from the `ansible` folder. Then, the desired roles will be copied into your project, and you can call them from Playbooks like any other role.
+
+#### Importing (Contributing) a Role to Galaxy
+
+Follow the instructions in [this template](https://github.com/CyVerse-Ansible/ansible-role-template) to publish an Ansible role to Galaxy and set up automated testing with Travis CI; then you can install the role into other projects.

--- a/src/contribution_guide/contribution_guide.md
+++ b/src/contribution_guide/contribution_guide.md
@@ -77,6 +77,7 @@ Not this:
 - shell: >
        	python a very long command --with=very --long-options=foo
        	--and-even=more_options --like-these
+
 ```
 
 #### Variables

--- a/src/contribution_guide/python.md
+++ b/src/contribution_guide/python.md
@@ -1,5 +1,5 @@
-Python
-======
+Python Style Guidelines
+=======================
 
 This Python style guide is largely copied from 
 [Center for Open Science](http://cosdev.readthedocs.io/en/latest/style_guides/python.html)

--- a/src/contribution_guide/python.md
+++ b/src/contribution_guide/python.md
@@ -1,0 +1,320 @@
+Python
+======
+
+This Python style guide is largely copied from 
+[Center for Open Science](http://cosdev.readthedocs.io/en/latest/style_guides/python.html)
+
+Follow [PEP8](http://www.python.org/dev/peps/pep-0008/), when sensible.
+
+Naming
+------
+
+-   Variables, functions, methods, packages, modules  
+    -   `lower_case_with_underscores`
+
+-   Classes and Exceptions  
+    -   `CapWords`
+
+-   Protected methods and internal functions  
+    -   `_single_leading_underscore(self, ...)`
+
+-   Private methods  
+    -   `__double_leading_underscore(self, ...)`
+
+-   Constants  
+    -   `ALL_CAPS_WITH_UNDERSCORES`
+
+### General Naming Guidelines
+
+Use singlequotes for strings, unless doing so requires lots of escaping.
+
+Avoid one-letter variables (esp. `l`, `O`, `I`).
+
+*Exception*: In very short blocks, when the meaning is clearly visible from the immediate context
+
+``` sourceCode
+for e in elements:
+    e.mutate()
+```
+
+Avoid redundant labeling.
+
+``` sourceCode
+# Yes
+import audio
+
+core = audio.Core()
+controller = audio.Controller()
+
+# No
+import audio
+
+core = audio.AudioCore()
+controller = audio.AudioController()
+```
+
+Prefer "reverse notation".
+
+``` sourceCode
+# Yes
+elements = ...
+elements_active = ...
+elements_defunct = ...
+
+# No
+elements = ...
+active_elements = ...
+defunct_elements ...
+```
+
+Avoid getter and setter methods.
+
+``` sourceCode
+# Yes
+person.age = 42
+
+# No
+person.set_age(42)
+```
+
+Indentation
+-----------
+
+Use 4 spaces--never tabs. You may need to change the settings in your text editor of choice.
+
+Imports
+-------
+
+Import entire modules instead of individual symbols within a module. For example, for a top-level module canteen that has a file canteen/sessions.py,
+
+``` sourceCode
+# Yes
+
+import canteen
+import canteen.sessions
+from canteen import sessions
+
+# No
+from canteen import get_user  # Symbol from canteen/__init__.py
+from canteen.sessions import get_session  # Symbol from canteen/sessions.py
+```
+
+*Exception*: For third-party code where documentation explicitly says to import individual symbols.
+
+*Rationale*: Avoids circular imports. See [here](https://sites.google.com/a/khanacademy.org/forge/for-developers/styleguide/python#TOC-Imports).
+
+Put all imports at the top of the page with three sections, each separated by a blank line, in this order:
+
+1.  System imports
+2.  Third-party imports
+3.  Local source tree imports
+
+*Rationale*: Makes it clear where each module is coming from.
+
+If you have intentionally have an unused import that exists only to make imports less verbose, be explicit about it. This will make sure that someone doesn't accidentally remove the import (not to mention that it keeps linters happy)
+
+``` sourceCode
+from my.very.distant.module import Frob
+
+Frob = Frob
+```
+
+String formatting
+-----------------
+
+Prefer `str.format` to "%-style" formatting.
+
+``` sourceCode
+# Yes
+'Hello {}'.format('World')
+ # OR
+'Hello {name}'.format(name='World')
+
+# No
+
+'Hello %s' % ('World', )
+```
+
+Print statements
+----------------
+
+Use the `print()` function rather than the `print` keyword (even if you're using Python 2).
+
+``` sourceCode
+# Yes
+print('Hello {}'.format(name))
+
+# No
+print 'Hello %s ' % name
+```
+
+Documentation
+-------------
+
+Follow [PEP257](http://www.python.org/dev/peps/pep-0257/)'s docstring guidelines. [reStructured Text](http://docutils.sourceforge.net/docs/user/rst/quickref.html) and [Sphinx](http://sphinx-doc.org/) can help to enforce these standards.
+
+All functions should have a docstring - for very simple functions, one line may be enough:
+
+    """Return the pathname of ``foo``."""
+
+Multiline docstrings should include:
+
+-   Summary line
+-   Use case, if appropriate
+-   Args
+-   Return type and semantics, unless `None` is returned
+
+<!-- -->
+
+    """Train a model to classify Foos and Bars.
+
+    Usage::
+
+        >>> import klassify
+        >>> data = [("green", "foo"), ("orange", "bar")]
+        >>> classifier = klassify.train(data)
+
+    :param train_data: A list of tuples of the form ``(color, label)``.
+    :return: A trained :class:`Classifier <Classifier>`
+    """
+
+Notes
+
+-   Use action words ("Return") rather than descriptions ("Returns").
+-   Document `__init__` methods in the docstring for the class.
+
+``` sourceCode
+class Person(object):
+    """A simple representation of a human being.
+
+    :param name: A string, the person's name.
+    :param age: An int, the person's age.
+    """
+    def __init__(self, name, age):
+        self.name = name
+        self.age = age
+```
+
+On Comments
+-----------
+
+Use them sparingly. Prefer code readability to writing a lot of comments. Often, small methods and functions are more effective than comments.
+
+``` sourceCode
+# Yes
+def is_stop_sign(sign):
+    return sign.color == 'red' and sign.sides == 8
+
+if is_stop_sign(sign):
+    stop()
+
+# No
+# If the sign is a stop sign
+if sign.color == 'red' and sign.sides == 8:
+    stop()
+```
+
+When you do write comments, use them to explain *why* a piece code was used, not *what* it does.
+
+### Method Overrides
+
+One useful place for comments are method overrides.
+
+``` sourceCode
+class UserDetail(generics.RetrieveUpdateAPIView, UserMixin):
+
+    # overrides RetrieveUpdateAPIView
+    def get_serializer_context(self):
+        return {'request': self.request}
+```
+
+Calling Superclasses' Methods
+-----------------------------
+
+Use super when there is only one superclass.
+
+``` sourceCode
+class Employee(Person):
+
+    def __init__(self, name):
+        super(Employee, self).__init__(name)
+        # or super().__init__(name) in Python 3
+        # ...
+```
+
+Call the method directly when there are multiple superclasses.
+
+``` sourceCode
+class DevOps(Developer, Operations):
+
+    def __init__(self):
+        Developer.__init__(self)
+        # ...
+```
+
+Line lengths
+------------
+
+Don't stress over it. 80-100 characters is fine.
+
+Use parentheses for line continuations.
+
+``` sourceCode
+wiki = (
+    "The Colt Python is a .357 Magnum caliber revolver formerly manufactured "
+    "by Colt's Manufacturing Company of Hartford, Connecticut. It is sometimes "
+    'referred to as a "Combat Magnum". It was first introduced in 1955, the '
+    "same year as Smith & Wesson's M29 .44 Magnum."
+)
+```
+
+Recommended Syntax Checkers
+---------------------------
+
+We recommend using a syntax checker to help you find errors quickly and easily format your code to abide by the guidelines above. [Flake8](http://flake8.readthedocs.org/en/latest/) is our recommended checker for Python. It will check for both syntax and style errors and is easily configurable. It can be installed with pip: :
+
+    $ pip install flake8
+
+Once installed, you can run a check with: :
+
+    $ flake8
+
+There are a number of plugins for integrating Flake8 with your preferred text editor.
+
+Vim
+
+-   [syntastic](https://github.com/scrooloose/syntastic) (multi-language)
+
+Sublime Text
+
+-   [Sublime Linter](https://sublime.wbond.net/packages/SublimeLinter) with [SublimeLinter-flake8](https://sublime.wbond.net/packages/SublimeLinter-flake8) (must install both)
+
+It is recommended that you use the git `pre-commit` hook to ensure your code
+is compliant with our style guide.
+
+```bash
+ln -s $(pwd)/contrib/pre-commit.hook $(pwd)/.git/hooks/pre-commit
+```
+
+To automate running tests before a push use the git `pre-push` hook to ensure
+your code passes all the tests.
+
+```bash
+ln -s $(pwd)/contrib/pre-push.hook $(pwd).git/hooks/pre-push
+```
+
+When master is pulled, it's helpful to know if a `pip install` or a `manage.py
+migrate` is necessary. To get other helpful warnings:
+
+```bash
+ln -s $(pwd)/contrib/post-merge.hook $(pwd)/.git/hooks/post-merge
+```
+
+Credits
+-------
+
+-   [Center for Open Science](http://cosdev.readthedocs.io/en/latest/style_guides/python.html)
+-   [PEP8](http://www.python.org/dev/peps/pep-0008/) (Style Guide for Python)
+-   [Pythonic Sensibilities](http://www.nilunder.com/blog/2013/08/03/pythonic-sensibilities/)
+-   [Python Best Practice Patterns](http://youtu.be/GZNUfkVIHAY)
+

--- a/src/index/00_welcome.md
+++ b/src/index/00_welcome.md
@@ -8,3 +8,4 @@ This site is intended to provide guides for how Atmosphere should be used. Both 
 - [Staff Guide](./staff_guide.html)
 - [User Guide](./user_guide.html)
 - [Imaging Guide](./imaging_guide.html)
+- [Atmosphere Contribution Guide](./contribution_guide.html)


### PR DESCRIPTION
Proposing this now because we have other Ansible refactoring efforts in the works.

I know the HTML output looks pretty bad: code blocks have broken indentation, H5 elements are smaller than normal text, table of contents needs more horizontal room, etc; this is a separate problem and @mgwall17 has agreed to help. Let's set that aside and talk about the content.

Todo:
- [ ] Link to this from readme of the other Atmosphere(1) repos, and from `contributing.md` (which triggers GitHub to prompt contributors when new PRs are opened):
  - atmosphere(2) (remove locally defined guidelines in readme)
  - troposphere
  - clank
  - atmosphere-ansible
  - atmosphere
  - atmosphere-guides
  - etc?