### PR TITLE
Migrating content from the internal wiki

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ gh-pages-commit:
 	git subtree push --prefix dist origin gh-pages
 
 build_html:
-	./scripts/to_html_template.sh index install_guide staff_guide user_guide imaging_guide connecting_cloud_provider contributing_to_atmosphere
+	./scripts/to_html_template.sh index install_guide staff_guide user_guide imaging_guide connecting_cloud_provider contributing_to_atmosphere troubleshooting_guide

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ gh-pages-commit:
 	git subtree push --prefix dist origin gh-pages
 
 build_html:
-	./scripts/to_html_template.sh index install_guide staff_guide user_guide imaging_guide connecting_cloud_provider
+	./scripts/to_html_template.sh index install_guide staff_guide user_guide imaging_guide connecting_cloud_provider contributing_to_atmosphere

--- a/dist/connecting_cloud_provider.html
+++ b/dist/connecting_cloud_provider.html
@@ -50,7 +50,7 @@
                       <li><a href="#grant-staffsuperuser-privileges">Grant Staff/Superuser Privileges</a></li>
                       <li><a href="#choose-an-allocation-strategy">Choose an Allocation Strategy</a></li>
                       <li><a href="#add-openstacks-imagesinstancessizes-to-atmosphere">Add OpenStack’s Images/Instances/Sizes to Atmosphere</a></li>
-                      <li><a href="#update-atmosphere-ansible-hosts-file">Update atmosphere-ansible hosts file</a></li>
+                      <li><a href="#update-atmosphere-ansible-hosts-file-and-group_vars">Update atmosphere-ansible hosts file and group_vars</a></li>
                       <li><a href="#test-atmosphere">Test Atmosphere!</a></li>
                       </ul></li>
                       </ul></li>
@@ -335,13 +335,14 @@
               monitor_sizes_for(8)
               monitor_machines_for(8)
               monitor_instances_for(8)  # Only necessary if `nova boot` was done out-of-band</code></pre>
-              <h4 id="update-atmosphere-ansible-hosts-file">Update atmosphere-ansible hosts file</h4>
+              <h4 id="update-atmosphere-ansible-hosts-file-and-group_vars">Update atmosphere-ansible hosts file and group_vars</h4>
               <p>Ensure that the hostnames of all your VMs are in <code>/opt/dev/atmosphere-ansible/ansible/hosts</code>, e.g.:</p>
               <pre><code>[atmosphere:children]
               atmosphere-mytestcloud
               
               [atmosphere-mytestcloud]
               vm7.mytestcloud.cyverse.org ansible_host=128.196.171.7 ansible_port=22</code></pre>
+              <p>Also ensure that you have appropriate group_vars defined in <code>/opt/dev/atmosphere-ansible/ansible/group/vars/name-of-your-cloud</code>.</p>
               <h4 id="test-atmosphere">Test Atmosphere!</h4>
               <p>In Atmosphere, try logging into the Troposphere UI as the account you added, selecting an image, and launching an instance.</p>
               </article>

--- a/dist/contributing_to_atmosphere.html
+++ b/dist/contributing_to_atmosphere.html
@@ -42,14 +42,6 @@
                       </ul></li>
                       <li><a href="#resources-and-docs-for-new-contributors">Resources and Docs for New Contributors</a></li>
                       <li><a href="#key-terms">Key Terms</a></li>
-                      <li><a href="#testing-and-deployment-workflows">Testing and Deployment Workflows</a><ul>
-                      <li><a href="#how-atmosphere-is-tested">How Atmosphere is Tested</a><ul>
-                      <li><a href="#django-tests-in-atmosphere2">Django tests in Atmosphere(2)</a></li>
-                      <li><a href="#travis-ci-running-style-bundlecompile-tests-for-troposphere"><a href="https://travis-ci.org/">Travis CI</a> running style &amp; bundle/compile tests for Troposphere</a></li>
-                      <li><a href="#qa-team-tests-using-robot-framework-and-jmeter">QA Team tests using Robot Framework and JMeter</a></li>
-                      <li><a href="#operation-sanity-behavioral-testing"><a href="https://github.com/cyverse/operation-sanity">Operation Sanity</a> behavioral testing</a></li>
-                      </ul></li>
-                      </ul></li>
                       <li><a href="#clouds">Clouds</a></li>
                       <li><a href="#tools-and-workflows">Tools and Workflows</a><ul>
                       <li><a href="#common-technologies-and-tools">Common Technologies and Tools</a></li>
@@ -58,6 +50,25 @@
                       <li><a href="#contributing-code">Contributing Code</a><ul>
                       <li><a href="#on-github">On Github</a></li>
                       </ul></li>
+                      </ul></li>
+                      <li><a href="#how-atmosphere-is-tested">How Atmosphere is Tested</a><ul>
+                      <li><a href="#django-tests-in-atmosphere2">Django tests in Atmosphere(2)</a></li>
+                      <li><a href="#travis-ci-running-style-bundlecompile-tests-for-troposphere"><a href="https://travis-ci.org/">Travis CI</a> running style &amp; bundle/compile tests for Troposphere</a></li>
+                      <li><a href="#qa-team-tests-using-robot-framework-and-jmeter">QA Team tests using Robot Framework and JMeter</a></li>
+                      <li><a href="#operation-sanity-behavioral-testing"><a href="https://github.com/cyverse/operation-sanity">Operation Sanity</a> behavioral testing</a></li>
+                      </ul></li>
+                      <li><a href="#releases-and-development-cycles">Releases and Development Cycles</a><ul>
+                      <li><a href="#release-naming">Release Naming</a></li>
+                      <li><a href="#approach-to-tagging-releases">Approach to Tagging Releases</a><ul>
+                      <li><a href="#note-on-sequence">Note on “Sequence”</a></li>
+                      <li><a href="#what-should-be-tagged">What Should Be Tagged?</a></li>
+                      </ul></li>
+                      <li><a href="#release-structure">Release Structure</a><ul>
+                      <li><a href="#first-2-week-sprint">First 2-week Sprint</a></li>
+                      <li><a href="#second-2-week-sprint">Second 2-week Sprint</a></li>
+                      <li><a href="#third-1-week-sprint">Third 1-week Sprint</a></li>
+                      </ul></li>
+                      <li><a href="#code-branching-strategy">Code Branching Strategy</a></li>
                       </ul></li>
                       </ul></li>
                       </ul>
@@ -84,6 +95,7 @@
               </ul>
               <h2 id="where-is-the-code">Where is the Code?</h2>
               <h3 id="repositories-on-github">Repositories on Github</h3>
+              <p>(Should we make this a table of repo + link + purpose?)</p>
               <ul>
               <li><a href="https://github.com/iplantcollaborativeopensource/atmosphere">atmosphere</a>(2), and supporting projects:
               <ul>
@@ -112,8 +124,6 @@
               <li><a href="/wiki/display/csmgmt/Atmosphere+Technology+Stack+Overview">Atmosphere Technology Stack Overview</a> (TODO fix broken link)</li>
               <li><a href="/wiki/display/csmgmt/Atmosphere+Troubleshooting+Orientation">Atmosphere Troubleshooting Orientation</a> (TODO fix broken link)</li>
               <li><a href="http://docs.atmospherev2.apiary.io/">Atmosphere(2) API docs on Apiary</a></li>
-              <li><a href="/wiki/display/csmgmt/Atmosphere+Staff+Manual">Atmosphere Staff Manual</a> containing information on releases (TODO fix broken link, incorporate that stuff here)</li>
-              <li><a href="/wiki/display/csmgmt/Approach+to+tagging+releases">Approach to tagging releases</a> (TODO fix broken link)</li>
               </ul>
               <h2 id="key-terms">Key Terms</h2>
               <p>You’ll hear these a lot on the Atmosphere project:</p>
@@ -124,45 +134,6 @@
               <li><em>Allocation Unit</em> <em>(AU)</em>: “roughly equivalent to using one CPU-hour, or to using one CPU core for one hour.” (<a href="https://pods.iplantcollaborative.org/wiki/display/atmman/Requesting+More+Atmosphere+Resources">source</a>) (TODO fix broken link)</li>
               <li><em>Modal</em>: a <a href="https://en.wikipedia.org/wiki/Modal_window">modal window</a> in a GUI; the Troposphere UI uses these extensively.</li>
               </ul>
-              <h2 id="testing-and-deployment-workflows">Testing and Deployment Workflows</h2>
-              <h3 id="how-atmosphere-is-tested">How Atmosphere is Tested</h3>
-              <p>The stack is tested at various levels; test coverage and the testing process is a work in progress.</p>
-              <h4 id="django-tests-in-atmosphere2">Django tests in Atmosphere(2)</h4>
-              <p>Unit tests written by developers can be found throughout the codebase. These tests are not currently running as part of regular build/deploy workflow, but we could!</p>
-              <h4 id="travis-ci-running-style-bundlecompile-tests-for-troposphere"><a href="https://travis-ci.org/">Travis CI</a> running style &amp; bundle/compile tests for Troposphere</h4>
-              <ul>
-              <li>see <a href="https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/.travis.yml">.travis.yml</a> in Troposphere for configuration</li>
-              <li><a href="https://travis-ci.org/iPlantCollaborativeOpenSource/troposphere">Troposphere test results on Travis CI</a></li>
-              </ul>
-              <h4 id="qa-team-tests-using-robot-framework-and-jmeter">QA Team tests using Robot Framework and JMeter</h4>
-              <p>Note that the following information describes processes performed by the QA Team at CyVerse who primarily support Atmosphere(0), but their effort certainly also benefits Atmosphere(1). This team is also responsible for testing other CyVerse products (e.g. Discovery Environment). Some resources described in this section are currently only accessiblt to members of CyVerse staff.</p>
-              <p>Tests are built based on QA team using and reverse engineering Atmosphere(1) on atmobeta.cyverse.org, and the history of internal JIRA issues. QA team does not currently receive product specifications or release notes.</p>
-              <p>Individual tests are tagged in a few dimensions:</p>
-              <ul>
-              <li>Type of test
-              <ul>
-              <li>Smoke tests, which confirm very basic communication/functionality/existence of API and UI objects</li>
-              <li>Functional tests, which confirm the actual functioning (“golden path”) of API endpoints and UI objects</li>
-              <li>Regression tests, which confirm that resolved issues do not recur and pushes boundaries</li>
-              </ul></li>
-              <li>Layer of stack under test
-              <ul>
-              <li>Atmosphere(2) API (HTTP calls using curl)</li>
-              <li>Troposphere UI (browser driven with Selenium)</li>
-              </ul></li>
-              </ul>
-              <p>atmobeta.cyverse.org is tested nightly, and test results can be found on <a href="https://shimerdas.iplantcollaborative.org:8443" class="uri">https://shimerdas.iplantcollaborative.org:8443</a>. (You must be a member of CyVerse staff and on an internal network to access shimerdas Jenkins server.) Only atmobeta is targeted during <em>regression</em> testing.</p>
-              <p>atmo-dev.cyverse.org is tested as part of each continuous deployment. Jenkins runs tests against atmo-dev in two jobs (these links are only accessible to CyVerse staff):</p>
-              <ul>
-              <li><a href="https://atmo-dev.cyverse.org/jenkins/job/Test_Atmosphere/">Test_Atmosphere</a> (API tests)</li>
-              <li><a href="https://atmo-dev.cyverse.org/jenkins/job/Test_Troposphere/">Test_Troposphere</a> (GUI tests)</li>
-              </ul>
-              <p>Test coverage is greater for the Atmosphere(2) API than for the Troposphere UI. QA team’s tests do not currently confirm that instances launch, nor do they execute the various instance access workflows (e.g. Web Shell and Web Desktop), but it is possible for this coverage to be added.</p>
-              <p>If a test fails repeatedly, QA team files a JIRA ticket, tags the test with the JIRA number, and disables that test until the issue is resolved.</p>
-              <p>More information on the QA team’s work can be found on <a href="http://qa-4.cyverse.org">qa-4.cyverse.org</a>, including the <a href="http://qa-4.cyverse.org/Atmosphere/">automated test suites</a> and how to run test suites locally (<a href="http://qa-4.cyverse.org/robotframework/misc/html/RobotFramework_and_iPlant.txt">1</a>, <a href="http://qa-4.cyverse.org/robotframework/misc/html/RobotFramework_Setup_for_iPlant-OLD.txt">2</a>). (Only accessible to CyVerse staff.) Note that much of the information is for other CyVerse projects, and some test framework dependencies are unnecessary if you are only testing Atmosphere.</p>
-              <h4 id="operation-sanity-behavioral-testing"><a href="https://github.com/cyverse/operation-sanity">Operation Sanity</a> behavioral testing</h4>
-              <p>Operation Sanity is a set of test suites written using behave, which drive a browser using Selenium. Operation Sanity exercises common Atmosphere workflows as a user: launches several instances against multiple cloud providers, ensures that those instances launch, creates and attaches volumes, and so forth. It is intended to run these tests in parallel so that long operations (e.g. waiting for an instance to launch) do not block execution.</p>
-              <p>Operation Sanity is currently in a “proof of concept” state, and is currently not run automatically. There is some intended functionality (e.g. testing launch of Web Shell and Web Desktop) which needs to be built.</p>
               <h2 id="clouds">Clouds</h2>
               <p>Atmosphere(0, 1, 2) provisions virtual machines on several ‘clouds’ which actually host the instances and computing infrastructure. Currently, all cloud providers use OpenStack. It is also possible for Atmosphere to provide access to commodity IaaS like Amazon Web Services (AWS), though this is not currently configured.</p>
               <h2 id="tools-and-workflows">Tools and Workflows</h2>
@@ -196,6 +167,109 @@
               <li><a href="https://github.com/iPlantCollaborativeOpenSource/troposphere">Troposphere</a>: <a href="https://github.com/lenards">Andrew Lenards</a></li>
               </ul>
               <p>Ancillary projects have a wider set of individuals with write access, these are typically members of the Atmosphere(0) team at CyVerse.</p>
+              <h2 id="how-atmosphere-is-tested">How Atmosphere is Tested</h2>
+              <p>The stack is tested at various levels; test coverage and the testing process is a work in progress.</p>
+              <h3 id="django-tests-in-atmosphere2">Django tests in Atmosphere(2)</h3>
+              <p>Unit tests written by developers can be found throughout the codebase. These tests are not currently running as part of regular build/deploy workflow, but we could!</p>
+              <h3 id="travis-ci-running-style-bundlecompile-tests-for-troposphere"><a href="https://travis-ci.org/">Travis CI</a> running style &amp; bundle/compile tests for Troposphere</h3>
+              <ul>
+              <li>see <a href="https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/.travis.yml">.travis.yml</a> in Troposphere for configuration</li>
+              <li><a href="https://travis-ci.org/iPlantCollaborativeOpenSource/troposphere">Troposphere test results on Travis CI</a></li>
+              </ul>
+              <h3 id="qa-team-tests-using-robot-framework-and-jmeter">QA Team tests using Robot Framework and JMeter</h3>
+              <p>Note that the following information describes processes performed by the QA Team at CyVerse who primarily support Atmosphere(0), but their effort certainly also benefits Atmosphere(1). This team is also responsible for testing other CyVerse products (e.g. Discovery Environment). Some resources described in this section are currently only accessiblt to members of CyVerse staff.</p>
+              <p>Tests are built based on QA team using and reverse engineering Atmosphere(1) on atmobeta.cyverse.org, and the history of internal JIRA issues. QA team does not currently receive product specifications or release notes.</p>
+              <p>Individual tests are tagged in a few dimensions:</p>
+              <ul>
+              <li>Type of test
+              <ul>
+              <li>Smoke tests, which confirm very basic communication/functionality/existence of API and UI objects</li>
+              <li>Functional tests, which confirm the actual functioning (“golden path”) of API endpoints and UI objects</li>
+              <li>Regression tests, which confirm that resolved issues do not recur and pushes boundaries</li>
+              </ul></li>
+              <li>Layer of stack under test
+              <ul>
+              <li>Atmosphere(2) API (HTTP calls using curl)</li>
+              <li>Troposphere UI (browser driven with Selenium)</li>
+              </ul></li>
+              </ul>
+              <p>atmobeta.cyverse.org is tested nightly, and test results can be found on <a href="https://shimerdas.iplantcollaborative.org:8443" class="uri">https://shimerdas.iplantcollaborative.org:8443</a>. (You must be a member of CyVerse staff and on an internal network to access shimerdas Jenkins server.) Only atmobeta is targeted during <em>regression</em> testing.</p>
+              <p>atmo-dev.cyverse.org is tested as part of each continuous deployment. Jenkins runs tests against atmo-dev in two jobs (these links are only accessible to CyVerse staff):</p>
+              <ul>
+              <li><a href="https://atmo-dev.cyverse.org/jenkins/job/Test_Atmosphere/">Test_Atmosphere</a> (API tests)</li>
+              <li><a href="https://atmo-dev.cyverse.org/jenkins/job/Test_Troposphere/">Test_Troposphere</a> (GUI tests)</li>
+              </ul>
+              <p>Test coverage is greater for the Atmosphere(2) API than for the Troposphere UI. QA team’s tests do not currently confirm that instances launch, nor do they execute the various instance access workflows (e.g. Web Shell and Web Desktop), but it is possible for this coverage to be added.</p>
+              <p>If a test fails repeatedly, QA team files a JIRA ticket, tags the test with the JIRA number, and disables that test until the issue is resolved.</p>
+              <p>More information on the QA team’s work can be found on <a href="http://qa-4.cyverse.org">qa-4.cyverse.org</a>, including the <a href="http://qa-4.cyverse.org/Atmosphere/">automated test suites</a> and how to run test suites locally (<a href="http://qa-4.cyverse.org/robotframework/misc/html/RobotFramework_and_iPlant.txt">1</a>, <a href="http://qa-4.cyverse.org/robotframework/misc/html/RobotFramework_Setup_for_iPlant-OLD.txt">2</a>). (Only accessible to CyVerse staff.) Note that much of the information is for other CyVerse projects, and some test framework dependencies are unnecessary if you are only testing Atmosphere.</p>
+              <h3 id="operation-sanity-behavioral-testing"><a href="https://github.com/cyverse/operation-sanity">Operation Sanity</a> behavioral testing</h3>
+              <p>Operation Sanity is a set of test suites written using behave, which drive a browser using Selenium. Operation Sanity exercises common Atmosphere workflows as a user: launches several instances against multiple cloud providers, ensures that those instances launch, creates and attaches volumes, and so forth. It is intended to run these tests in parallel so that long operations (e.g. waiting for an instance to launch) do not block execution.</p>
+              <p>Operation Sanity is currently in a “proof of concept” state, and is currently not run automatically. There is some intended functionality (e.g. testing launch of Web Shell and Web Desktop) which needs to be built.</p>
+              <h2 id="releases-and-development-cycles">Releases and Development Cycles</h2>
+              <p>You can see a list of releases as branches in each GitHub repository, e.g. <a href="https://github.com/cyverse/atmosphere/branches">Atmosphere(2)</a>.</p>
+              <h3 id="release-naming">Release Naming</h3>
+              <p>Name should be two words, a hyphen will be added between them. Hyphenated bird names used to be the golden ticket (Abyssinian-nightjar,california-condor) but we now allow for alliterative adjective/verb and bird name combinations (ex: jamming-junglefowl, mystifying-merlin, nautical-nighthawk). Helpful Link: <a href="http://thewebsiteofeverything.com/animals/birds/beginning-with/A">Birds Beginning with Letters</a></p>
+              <h3 id="approach-to-tagging-releases">Approach to Tagging Releases</h3>
+              <p>In order to identify which release a repository is associated with, we need to “tag”, or annotate, the association. Currently, we name branches by release for Atmosphere &amp; Troposphere. However, there are dependencies in the instance deployment automation managed in Atmosphere-Ansible repository. This repo is used by “subspace” via Atmosphere API - yet, we are not explicitly denoting the Atmosphere-Ansible tested, verified, and deployed with an Atmosphere release.</p>
+              <p>I suggest that we use <a href="https://git-scm.com/book/en/v2/Git-Basics-Tagging#Annotated-Tags">“annotated-tags”</a> over lightweight tags; this allows for a “tag name” and a message.</p>
+              <p>Given that we use letter-based alliterations for release names, I suggest was use a two-digit year plus letter initials as our <em>annotation</em>. So, petrified-penguin would be 16.p-p as the initial release. If there was patches applied to release, then it would be incremental:</p>
+              <ul>
+              <li>16-p-p-1</li>
+              <li>16-p-p-2</li>
+              <li>16-q-q</li>
+              <li>16-q-q-1</li>
+              <li>16-r-r</li>
+              <li>16-r-r-1</li>
+              <li>16-r-r-2</li>
+              <li>16-s-s</li>
+              <li>16-t-t</li>
+              <li>17-u-u</li>
+              <li>17-u-u-1</li>
+              <li>17-v-v</li>
+              <li>17-v-v-1</li>
+              </ul>
+              <p>Applying an annotated tag to a repository would allow a tag-name and a message. We’d then push to the origin without specifying a branch:</p>
+              <pre><code>GIT_TAG=&quot;16-s-s&quot;
+              git tag -a $GIT_TAG -m &quot;Solitary-Snipe released.&quot; &amp;&amp; git push origin --tags&lt;/pre&gt;</code></pre>
+              <h4 id="note-on-sequence">Note on “Sequence”</h4>
+              <p>The tag-name should be “two-digit” year concatenated with “release initials” (ravenous-raven shortens to r-r). Only add an incremented integer if more than one tag for a release is needed.</p>
+              <h4 id="what-should-be-tagged">What Should Be Tagged?</h4>
+              <p>The repositories that <strong>should</strong> be tagged for a release are as follows:</p>
+              <ul>
+              <li>Atmosphere (&lt;<release-name>&gt; branch) - <a href="https://github.com/iPlantCollaborativeOpenSource/atmosphere">repo</a></li>
+              <li>Troposphere (&lt;<release-name>&gt; branch) - <a href="https://github.com/iPlantCollaborativeOpenSource/troposphere">repo</a></li>
+              <li>Atmosphere-Ansible (master) - <a href="https://github.com/iPlantCollaborativeOpenSource/atmosphere-ansible">repo</a></li>
+              <li>Clank (master - maybe a feature-branch) - <a href="https://github.com/iPlantCollaborativeOpenSource/clank">repo</a></li>
+              <li>nginx_novnc_auth (master) - <a href="https://github.com/cyverse/nginx_novnc_auth">repo</a></li>
+              </ul>
+              <p>We should consider tagging this fork - <a href="https://github.com/edwins/gateone" class="uri">https://github.com/edwins/gateone</a></p>
+              <h3 id="release-structure">Release Structure</h3>
+              <p>The structure of releases is inspired by <a href="http://blog.assembla.com/AssemblaBlog/tabid/12618/bid/36341/Secrets-of-rapid-release-cycles-from-the-Google-Chrome-team.aspx">Chrome/Chromium</a>. We aim to deliver new code to production every 5 weeks. Those 5 weeks are split into 3 sprints (2 sprints of 2-weeks and a single 1-week sprint).</p>
+              <h4 id="first-2-week-sprint">First 2-week Sprint</h4>
+              <ul>
+              <li>new feature development</li>
+              <li>upgrading dependencies</li>
+              <li>testing/verification</li>
+              </ul>
+              <h4 id="second-2-week-sprint">Second 2-week Sprint</h4>
+              <ul>
+              <li>Priority bug fixes</li>
+              <li>feature development <em>continued</em></li>
+              <li>testing/verification</li>
+              </ul>
+              <h4 id="third-1-week-sprint">Third 1-week Sprint</h4>
+              <ul>
+              <li>Any committed works left to finish</li>
+              <li>Priority/Critical tickets</li>
+              <li>testing/verification</li>
+              </ul>
+              <h3 id="code-branching-strategy">Code Branching Strategy</h3>
+              <p>(Note that the following section contains links to environments that are only accessible to members of CyVerse staff.)</p>
+              <p>The master branch collects new feature development and community contributions. <a href="http://atmo-dev.cyverse.org" class="uri">http://atmo-dev.cyverse.org</a> generally tracks master. Other feature branches are used as needed.</p>
+              <p>The ‘beta’ / ‘next release’ branch collects stability improvements and bug fixes; it does not typically receive new features. <a href="http://atmobeta.cyverse.org/">http://atmobeta.cyverse.org</a> generally tracks the next release.</p>
+              <p>Think of each five-week cycle as an effort to 1. develop new features on the master branch, and 2. stabilize the beta/release branch for deployment to production.</p>
+              <p>Bug fixes and other changes are regularly “trickled down” from the beta/release branch to the master branch, and when necessary, from production systems to beta/release.</p>
+              <p>Following each release, any changes in the release branch are merged back into master. Then, master is branched into the ‘next release’ and the cycle repeats.</p>
               </article>
             </div> <!-- #main -->
         </div> <!-- #main-container -->

--- a/dist/contributing_to_atmosphere.html
+++ b/dist/contributing_to_atmosphere.html
@@ -1,0 +1,222 @@
+<!doctype html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang=""> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8" lang=""> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9" lang=""> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang=""> <!--<![endif]-->
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta http-equiv="Content-Style-Type" content="text/css" />
+        <meta name="generator" content="pandoc" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+                    <title></title>
+        <style type="text/css">code{white-space: pre;}</style>
+                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" type="text/css" />
+                    <link rel="icon" href="themes/cyverse/media/favicon.ico" type="image/x-icon">
+        <link rel="stylesheet" href="themes/cyverse/media/css/normalize.min.css">
+        <link rel="stylesheet" href="themes/cyverse/media/css/main.css">
+        <script src="themes/cyverse/media/js/vendor/modernizr-2.8.3-respond-1.4.2.min.js"></script>
+          </head>
+    <body>
+        <!--[if lt IE 8]>
+            <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+        <![endif]-->
+
+                <div class="header-container">
+            <header class="wrapper clearfix">
+                <div class="logo"><img src="themes/cyverse/media/cyverse_logo.png" alt="Staff Guide"></div>
+                <h1 class="title"></h1>
+            </header>
+        </div>
+        
+        <div class="main-container">
+            <div class="main wrapper clearfix">
+              <!-- TABLE OF CONTENTS -->
+                                  <aside>
+                      <h3> TABLE OF CONTENTS </h3>
+                      <ul>
+                      <li><a href="#contributing-to-atmosphere">Contributing to Atmosphere</a><ul>
+                      <li><a href="#what-is-atmosphere">What is Atmosphere?</a></li>
+                      <li><a href="#where-is-atmosphere-deployed">Where is Atmosphere Deployed?</a></li>
+                      <li><a href="#where-is-the-code">Where is the Code?</a><ul>
+                      <li><a href="#repositories-on-github">Repositories on Github</a></li>
+                      </ul></li>
+                      <li><a href="#resources-and-docs-for-new-contributors">Resources and Docs for New Contributors</a></li>
+                      <li><a href="#key-terms">Key Terms</a></li>
+                      <li><a href="#testing-and-deployment-workflows">Testing and Deployment Workflows</a><ul>
+                      <li><a href="#how-atmosphere-is-tested">How Atmosphere is Tested</a><ul>
+                      <li><a href="#django-tests-in-atmosphere2">Django tests in Atmosphere(2)</a></li>
+                      <li><a href="#travis-ci-running-style-bundlecompile-tests-for-troposphere"><a href="https://travis-ci.org/">Travis CI</a> running style &amp; bundle/compile tests for Troposphere</a></li>
+                      <li><a href="#qa-team-tests-using-robot-framework-and-jmeter">QA Team tests using Robot Framework and JMeter</a></li>
+                      <li><a href="#operation-sanity-behavioral-testing"><a href="https://github.com/cyverse/operation-sanity">Operation Sanity</a> behavioral testing</a></li>
+                      </ul></li>
+                      </ul></li>
+                      <li><a href="#clouds">Clouds</a></li>
+                      <li><a href="#tools-and-workflows">Tools and Workflows</a><ul>
+                      <li><a href="#common-technologies-and-tools">Common Technologies and Tools</a></li>
+                      <li><a href="#local-development-environment">Local Development Environment</a></li>
+                      <li><a href="#issue-tracking-systems">Issue Tracking Systems</a></li>
+                      <li><a href="#contributing-code">Contributing Code</a><ul>
+                      <li><a href="#on-github">On Github</a></li>
+                      </ul></li>
+                      </ul></li>
+                      </ul></li>
+                      </ul>
+                  </aside>
+                              <!-- MAIN CONTENT -->
+              <article>
+              <h1 id="contributing-to-atmosphere">Contributing to Atmosphere</h1>
+              <p>This page is recovering from major surgery (Atmosphere(0)-related content was left on the CyVerse wiki). The broken links will be fixed soon.</p>
+              <p>This guide is intended to orient community members who are interested in contributing to Atmosphere. Welcome to the project!</p>
+              <h2 id="what-is-atmosphere">What is Atmosphere?</h2>
+              <p>Atmosphere or ‘atmo’ can refer to several different things:</p>
+              <ul>
+              <li><a href="https://atmo.cyverse.org/application">Atmosphere</a>(0), CyVerse’s “cloud computing for scientists” service</li>
+              <li><a href="/wiki/display/csmgmt/Atmosphere+Technology+Stack+Overview">Atmosphere</a>(1), <strong>the free, open-source software project</strong> which powers the above service (and is the primary focus of these guides) (TODO fix broken link)</li>
+              <li><a href="https://github.com/iPlantCollaborativeOpenSource/atmosphere">Atmosphere</a>(2), the API and back-end component of the above software project</li>
+              </ul>
+              <p>For clarity, this page will disambiguate all uses of “Atmosphere”.</p>
+              <h2 id="where-is-atmosphere-deployed">Where is Atmosphere Deployed?</h2>
+              <p>Atmosphere(1) is deployed at CyVerse as Atmosphere(0), but also at several other organizations known by different names:</p>
+              <ul>
+              <li><a href="http://jetstream-cloud.org/">Jetstream Cloud</a> (partnership of Indiana University, TACC, &amp; CyVerse - Jetstream GitHub Organization: <a href="https://github.com/jetstream-cloud">jetstream-cloud</a>)</li>
+              <li>MOC (Massechusetts Open Cloud) (Jonathan Bell: <a href="https://github.com/lokI8">github-profile</a>, Lucas H. Xu: <a href="https://github.com/xuhang57">github-profile</a>)</li>
+              <li>Duke University / Duke Center for Genomic &amp; Computational Biology (<a href="https://github.com/Duke-GCB">Duke GCB</a>) (Darren Boss: <a href="https://genome.duke.edu/directory/gcb-staff/darren-boss">gcb-profile</a>; <a href="https://github.com/netscruff">github-profile</a>)</li>
+              </ul>
+              <h2 id="where-is-the-code">Where is the Code?</h2>
+              <h3 id="repositories-on-github">Repositories on Github</h3>
+              <ul>
+              <li><a href="https://github.com/iplantcollaborativeopensource/atmosphere">atmosphere</a>(2), and supporting projects:
+              <ul>
+              <li><a href="https://github.com/iPlantCollaborativeOpenSource/django-iplant-auth">django-iplant-auth</a> (used by Django backends of Atmosphere &amp; Troposphere)</li>
+              <li><a href="https://github.com/iPlantCollaborativeOpenSource/subspace">subspace</a> (runs the Ansible for instance deploys)</li>
+              <li><a href="https://github.com/iPlantCollaborativeOpenSource/rtwo">rtwo</a></li>
+              <li><a href="https://github.com/iPlantCollaborativeOpenSource/chromogenic">chromogenic</a> (Imaging using in Atmosphere)</li>
+              <li><a href="https://github.com/jmatt/threepio">threepio</a> (will be replaced as Django logging has improved since it was created)</li>
+              <li><a href="https://github.com/iPlantCollaborativeOpenSource/atmosphere-v2-apiary-docs">atmosphere-v2-apiary-docs</a>, some API documentation?</li>
+              <li><a href="https://github.com/iPlantCollaborativeOpenSource/atmosphere-apiary-docs">atmosphere-apiary-docs</a>, some old API documentation?</li>
+              </ul></li>
+              <li><a href="https://github.com/iplantcollaborativeopensource/troposphere">troposphere</a>, and supporting projects:
+              <ul>
+              <li><a href="https://github.com/cyverse/troposphere-ui">troposphere-ui,</a> soon to be used by Troposphere</li>
+              </ul></li>
+              <li><a href="https://github.com/iPlantCollaborativeOpenSource/atmosphere-ansible">atmosphere-ansible</a></li>
+              <li><a href="https://github.com/iPlantCollaborativeOpenSource/clank">clank</a>, Ansible-based automation which deploys Atmosphere(1)</li>
+              <li><a href="https://github.com/cyverse/nginx_novnc_auth">nginx_novnc_auth</a></li>
+              <li><a href="https://github.com/edwins/GateOne">edwins/GateOne</a></li>
+              <li><a href="https://github.com/cyverse/atmosphere-guides">ansible-gateone-server</a></li>
+              <li><a href="https://github.com/cyverse/atmosphere-guides">atmosphere-guides</a> documentation for Atmosphere(1)</li>
+              </ul>
+              <h2 id="resources-and-docs-for-new-contributors">Resources and Docs for New Contributors</h2>
+              <p>Familiarize yourself with the following links and use them as a reference.</p>
+              <ul>
+              <li><a href="/wiki/display/csmgmt/Atmosphere+Technology+Stack+Overview">Atmosphere Technology Stack Overview</a> (TODO fix broken link)</li>
+              <li><a href="/wiki/display/csmgmt/Atmosphere+Troubleshooting+Orientation">Atmosphere Troubleshooting Orientation</a> (TODO fix broken link)</li>
+              <li><a href="http://docs.atmospherev2.apiary.io/">Atmosphere(2) API docs on Apiary</a></li>
+              <li><a href="/wiki/display/csmgmt/Atmosphere+Staff+Manual">Atmosphere Staff Manual</a> containing information on releases (TODO fix broken link, incorporate that stuff here)</li>
+              <li><a href="/wiki/display/csmgmt/Approach+to+tagging+releases">Approach to tagging releases</a> (TODO fix broken link)</li>
+              </ul>
+              <h2 id="key-terms">Key Terms</h2>
+              <p>You’ll hear these a lot on the Atmosphere project:</p>
+              <ul>
+              <li><em>Instance</em>: a Virtual Machine (VM) or “cloud computer” running on Atmosphere(0) / OpenStack.</li>
+              <li><em>Image:</em> a <a href="https://en.wikipedia.org/wiki/Disk_image">disk image</a> of a Virtual Machine (with some metadata) from which instances are created.</li>
+              <li><em>Allocation</em>: the amount of “CPU time” that a user is allotted, measured in AUs (see below).</li>
+              <li><em>Allocation Unit</em> <em>(AU)</em>: “roughly equivalent to using one CPU-hour, or to using one CPU core for one hour.” (<a href="https://pods.iplantcollaborative.org/wiki/display/atmman/Requesting+More+Atmosphere+Resources">source</a>) (TODO fix broken link)</li>
+              <li><em>Modal</em>: a <a href="https://en.wikipedia.org/wiki/Modal_window">modal window</a> in a GUI; the Troposphere UI uses these extensively.</li>
+              </ul>
+              <h2 id="testing-and-deployment-workflows">Testing and Deployment Workflows</h2>
+              <h3 id="how-atmosphere-is-tested">How Atmosphere is Tested</h3>
+              <p>The stack is tested at various levels; test coverage and the testing process is a work in progress.</p>
+              <h4 id="django-tests-in-atmosphere2">Django tests in Atmosphere(2)</h4>
+              <p>Unit tests written by developers can be found throughout the codebase. These tests are not currently running as part of regular build/deploy workflow, but we could!</p>
+              <h4 id="travis-ci-running-style-bundlecompile-tests-for-troposphere"><a href="https://travis-ci.org/">Travis CI</a> running style &amp; bundle/compile tests for Troposphere</h4>
+              <ul>
+              <li>see <a href="https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/.travis.yml">.travis.yml</a> in Troposphere for configuration</li>
+              <li><a href="https://travis-ci.org/iPlantCollaborativeOpenSource/troposphere">Troposphere test results on Travis CI</a></li>
+              </ul>
+              <h4 id="qa-team-tests-using-robot-framework-and-jmeter">QA Team tests using Robot Framework and JMeter</h4>
+              <p>Note that the following information describes processes performed by the QA Team at CyVerse who primarily support Atmosphere(0), but their effort certainly also benefits Atmosphere(1). This team is also responsible for testing other CyVerse products (e.g. Discovery Environment). Some resources described in this section are currently only accessiblt to members of CyVerse staff.</p>
+              <p>Tests are built based on QA team using and reverse engineering Atmosphere(1) on atmobeta.cyverse.org, and the history of internal JIRA issues. QA team does not currently receive product specifications or release notes.</p>
+              <p>Individual tests are tagged in a few dimensions:</p>
+              <ul>
+              <li>Type of test
+              <ul>
+              <li>Smoke tests, which confirm very basic communication/functionality/existence of API and UI objects</li>
+              <li>Functional tests, which confirm the actual functioning (“golden path”) of API endpoints and UI objects</li>
+              <li>Regression tests, which confirm that resolved issues do not recur and pushes boundaries</li>
+              </ul></li>
+              <li>Layer of stack under test
+              <ul>
+              <li>Atmosphere(2) API (HTTP calls using curl)</li>
+              <li>Troposphere UI (browser driven with Selenium)</li>
+              </ul></li>
+              </ul>
+              <p>atmobeta.cyverse.org is tested nightly, and test results can be found on <a href="https://shimerdas.iplantcollaborative.org:8443" class="uri">https://shimerdas.iplantcollaborative.org:8443</a>. (You must be a member of CyVerse staff and on an internal network to access shimerdas Jenkins server.) Only atmobeta is targeted during <em>regression</em> testing.</p>
+              <p>atmo-dev.cyverse.org is tested as part of each continuous deployment. Jenkins runs tests against atmo-dev in two jobs (these links are only accessible to CyVerse staff):</p>
+              <ul>
+              <li><a href="https://atmo-dev.cyverse.org/jenkins/job/Test_Atmosphere/">Test_Atmosphere</a> (API tests)</li>
+              <li><a href="https://atmo-dev.cyverse.org/jenkins/job/Test_Troposphere/">Test_Troposphere</a> (GUI tests)</li>
+              </ul>
+              <p>Test coverage is greater for the Atmosphere(2) API than for the Troposphere UI. QA team’s tests do not currently confirm that instances launch, nor do they execute the various instance access workflows (e.g. Web Shell and Web Desktop), but it is possible for this coverage to be added.</p>
+              <p>If a test fails repeatedly, QA team files a JIRA ticket, tags the test with the JIRA number, and disables that test until the issue is resolved.</p>
+              <p>More information on the QA team’s work can be found on <a href="http://qa-4.cyverse.org">qa-4.cyverse.org</a>, including the <a href="http://qa-4.cyverse.org/Atmosphere/">automated test suites</a> and how to run test suites locally (<a href="http://qa-4.cyverse.org/robotframework/misc/html/RobotFramework_and_iPlant.txt">1</a>, <a href="http://qa-4.cyverse.org/robotframework/misc/html/RobotFramework_Setup_for_iPlant-OLD.txt">2</a>). (Only accessible to CyVerse staff.) Note that much of the information is for other CyVerse projects, and some test framework dependencies are unnecessary if you are only testing Atmosphere.</p>
+              <h4 id="operation-sanity-behavioral-testing"><a href="https://github.com/cyverse/operation-sanity">Operation Sanity</a> behavioral testing</h4>
+              <p>Operation Sanity is a set of test suites written using behave, which drive a browser using Selenium. Operation Sanity exercises common Atmosphere workflows as a user: launches several instances against multiple cloud providers, ensures that those instances launch, creates and attaches volumes, and so forth. It is intended to run these tests in parallel so that long operations (e.g. waiting for an instance to launch) do not block execution.</p>
+              <p>Operation Sanity is currently in a “proof of concept” state, and is currently not run automatically. There is some intended functionality (e.g. testing launch of Web Shell and Web Desktop) which needs to be built.</p>
+              <h2 id="clouds">Clouds</h2>
+              <p>Atmosphere(0, 1, 2) provisions virtual machines on several ‘clouds’ which actually host the instances and computing infrastructure. Currently, all cloud providers use OpenStack. It is also possible for Atmosphere to provide access to commodity IaaS like Amazon Web Services (AWS), though this is not currently configured.</p>
+              <h2 id="tools-and-workflows">Tools and Workflows</h2>
+              <h3 id="common-technologies-and-tools">Common Technologies and Tools</h3>
+              <p>No matter your sub-specialty, you’ll work with most/all of these as a member of the Atmosphere Team.</p>
+              <ul>
+              <li>Python programming language, used for Atmosphere(2), Ansible, Subspace</li>
+              <li>Ansible, used for configuration management and infrastructure automation</li>
+              <li>YAML markup language, used for Ansible code and variables files</li>
+              <li>Markdown markup language, used for documentation</li>
+              <li>SSH, used for remotely accessing servers</li>
+              <li>git and Github, used for source control</li>
+              </ul>
+              <h3 id="local-development-environment">Local Development Environment</h3>
+              <p>The local development environment-in-a-box is not yet published for community consumption. Coming soon!</p>
+              <h3 id="issue-tracking-systems">Issue Tracking Systems</h3>
+              <p>The Atmosphere(0) team uses several internal systems to track development cycles and support issues. Unfortunately these are not accessible to community members. For now, please use the repository-specific Issues section in the appropriate GitHub repository (perhaps <a href="https://github.com/cyverse/atmosphere">atmosphere</a>(2)) to report an issue with Atmosphere(1,2).</p>
+              <p>If you are an Atmosphere(0) <em>user</em> seeking assistance and you ended up here for some reason, please log into <a href="https://atmo.cyverse.org/">Atmosphere</a> and click the “Feedback &amp; Support” link at the bottom of the page, or email support at cyverse dot org.</p>
+              <h3 id="contributing-code">Contributing Code</h3>
+              <p>Note that the following information may change soon as the Atmosphere(0) team refines the development process for Atmosphere(1).</p>
+              <h4 id="on-github">On Github</h4>
+              <p>Most of Atmosphere(1)’s code lives on GitHub. Contributions to these codebases should follow a fork-and-pull-request workflow.</p>
+              <ol style="list-style-type: decimal">
+              <li>Create your own fork of the repository, work on the code there, test it in your local development environment</li>
+              <li>Create a pull request</li>
+              <li>Have someone else review and merge your pull request; ideally two people will review it.</li>
+              </ol>
+              <p>Forward-facing projects that are critical to Atmosphere(1) have designated point maintainers. Pull requests to these projects should be approved by the point maintainer when possible:</p>
+              <ul>
+              <li><a href="https://github.com/iplantcollaborativeopensource/atmosphere">Atmosphere</a>(2): <a href="https://github.com/steve-gregory">Steve Gregory</a></li>
+              <li><a href="https://github.com/iPlantCollaborativeOpenSource/troposphere">Troposphere</a>: <a href="https://github.com/lenards">Andrew Lenards</a></li>
+              </ul>
+              <p>Ancillary projects have a wider set of individuals with write access, these are typically members of the Atmosphere(0) team at CyVerse.</p>
+              </article>
+            </div> <!-- #main -->
+        </div> <!-- #main-container -->
+
+                <div class="footer-container">
+            <footer class="wrapper">
+                    <footer class="footer"> <!-- Needs to be a `include-after` -->
+          		<div class="container">
+          		  <div class="region region-footer">
+          		    <section id="block-block-25" class="block block-block clearfix">
+          		      <p><img alt="Cyverse" src="./media/cyverse_icon_transp2.png" style="width: 25px; height: 24px;">&nbsp;<a href="http://www.cyverse.org/">CyVerse</a> | <a href="http://www.cyverse.org/open-source">Open Source</a> | <img alt="NSF" src="./media/nsf1.gif" style="width: 25px; height: 25px;">&nbsp;</p>
+          		    </section>
+          		  </div>
+          		</div>
+        	    </footer>
+            </footer>
+        </div>
+        <!-- Included at the end of body -->
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+        <script>window.jQuery || document.write('<script src="themes/cyverse/media/js/vendor/jquery-1.11.2.min.js"><\/script>')</script>
+        
+        <script src="themes/cyverse/media/js/main.js"></script>
+            </body>
+</html>

--- a/dist/contributing_to_atmosphere.html
+++ b/dist/contributing_to_atmosphere.html
@@ -42,6 +42,27 @@
                       </ul></li>
                       <li><a href="#resources-and-docs-for-new-contributors">Resources and Docs for New Contributors</a></li>
                       <li><a href="#key-terms">Key Terms</a></li>
+                      <li><a href="#technology-stack-overview">Technology Stack Overview</a><ul>
+                      <li><a href="#atmosphere1">Atmosphere(1)</a><ul>
+                      <li><a href="#atmosphere2-api-and-back-end">Atmosphere(2) API and Back-End</a></li>
+                      <li><a href="#troposphere-ui">Troposphere UI</a></li>
+                      <li><a href="#web-server">Web Server</a></li>
+                      <li><a href="#atmosphere-ansible">atmosphere-ansible</a></li>
+                      </ul></li>
+                      <li><a href="#clank">Clank</a></li>
+                      <li><a href="#monitoring-and-management">Monitoring and Management</a><ul>
+                      <li><a href="#elk">ELK</a></li>
+                      <li><a href="#new-relic">New Relic</a></li>
+                      <li><a href="#sentry">Sentry</a></li>
+                      </ul></li>
+                      <li><a href="#openstack">OpenStack</a></li>
+                      <li><a href="#remote-access-methods">Remote Access Methods</a><ul>
+                      <li><a href="#ssh">SSH</a></li>
+                      <li><a href="#web-shell">Web Shell</a></li>
+                      <li><a href="#web-desktop">Web Desktop</a></li>
+                      <li><a href="#future-guacamole">Future: Guacamole</a></li>
+                      </ul></li>
+                      </ul></li>
                       <li><a href="#clouds">Clouds</a></li>
                       <li><a href="#tools-and-workflows">Tools and Workflows</a><ul>
                       <li><a href="#common-technologies-and-tools">Common Technologies and Tools</a></li>
@@ -121,7 +142,6 @@
               <h2 id="resources-and-docs-for-new-contributors">Resources and Docs for New Contributors</h2>
               <p>Familiarize yourself with the following links and use them as a reference.</p>
               <ul>
-              <li><a href="/wiki/display/csmgmt/Atmosphere+Technology+Stack+Overview">Atmosphere Technology Stack Overview</a> (TODO fix broken link)</li>
               <li><a href="/wiki/display/csmgmt/Atmosphere+Troubleshooting+Orientation">Atmosphere Troubleshooting Orientation</a> (TODO fix broken link)</li>
               <li><a href="http://docs.atmospherev2.apiary.io/">Atmosphere(2) API docs on Apiary</a></li>
               </ul>
@@ -134,6 +154,54 @@
               <li><em>Allocation Unit</em> <em>(AU)</em>: “roughly equivalent to using one CPU-hour, or to using one CPU core for one hour.” (<a href="https://pods.iplantcollaborative.org/wiki/display/atmman/Requesting+More+Atmosphere+Resources">source</a>) (TODO fix broken link)</li>
               <li><em>Modal</em>: a <a href="https://en.wikipedia.org/wiki/Modal_window">modal window</a> in a GUI; the Troposphere UI uses these extensively.</li>
               </ul>
+              <h2 id="technology-stack-overview">Technology Stack Overview</h2>
+              <p>This is intended to be an orientation to the main components of Atmosphere(1), their purpose, and their supporting technologies.</p>
+              <h3 id="atmosphere1">Atmosphere(1)</h3>
+              <p>Atmosphere(1), broadly, is a web application which supports user-friendly access to (and management of) cloud computing resources, such as virtual machines (servers/workstations) and storage volumes.</p>
+              <p>Atmosphere(1) has a “micro-services” architecture in that the back-end API is separated from the front-end UI, but all deployments to date contain all components on one operating system environment (server).</p>
+              <h4 id="atmosphere2-api-and-back-end">Atmosphere(2) API and Back-End</h4>
+              <p>The API is written in Python using the <a href="https://www.djangoproject.com/">Django</a> web framework, backed by a <a href="https://en.wikipedia.org/wiki/PostgreSQL">PostgreSQL</a> database. As is typical for Django applications, Atmosphere(2) interacts with its database using Django’s <a href="https://en.wikipedia.org/wiki/Object-relational_mapping">object-relational mapper</a>.</p>
+              <p>Things that Atmosphere(2) does:</p>
+              <ul>
+              <li>Interacts with cloud provider APIs to provision resources (instances, block storage volumes)</li>
+              <li>Initiates Ansible playbook runs on new and redeployed instances</li>
+              <li>Authenticates users</li>
+              <li>Keeps track of user <a href="http://www.cyverse.org/service-level-agreement#AtmoAllo">allocations</a></li>
+              </ul>
+              <p>The API is <a href="http://docs.atmospherev2.apiary.io/#reference">apparently documented here</a>.</p>
+              <h4 id="troposphere-ui">Troposphere UI</h4>
+              <p><a href="/wiki/display/csmgmt/Troposphere">Troposphere</a> is a separate front-end for Atmosphere(1), consisting of a Django application and JavaScript “single-page application” built with the <a href="https://facebook.github.io/react/">React</a> front-end framework. Troposphere can be thought of as a JavaScript client which interacts with Atmosphere(2) via RESTful API.</p>
+              <h4 id="web-server">Web Server</h4>
+              <p>Both Atmosphere(2) and Troposphere are served by Nginx, which serves static assets directly and reverse proxies to uWSGI (etc.) for dynamically generated content.</p>
+              <h4 id="atmosphere-ansible">atmosphere-ansible</h4>
+              <p>atmosphere-ansible is the set of Ansible code that runs on newly provisioned cloud instances as part of the deployment process.</p>
+              <h5 id="subspace">Subspace</h5>
+              <p><a href="https://github.com/iPlantCollaborativeOpenSource/subspace">Subspace</a> is a Python project that programmatically runs Ansible playbooks; Atmosphere(2) uses it to run atmosphere-ansible.</p>
+              <h3 id="clank">Clank</h3>
+              <p><a href="https://github.com/iPlantCollaborativeOpenSource/clank">Clank</a> is the set of automations that deploy Atmosphere(1) and most of its components.</p>
+              <p>Clank wraps the deployment process using Ansible, but significant parts are still automated with a mix of bash scripting, makefile, and a custom Python “configure” script which generates application configuration from jinja2 templates and .ini files. Also, unlike other Ansible code that you may have seen, Clank must be run locally on the destination server, not from a remote deployment host. The future direction is to refactor this into idiomatic Ansible and remove some layers of indirection.</p>
+              <h3 id="monitoring-and-management">Monitoring and Management</h3>
+              <p>These are optional integrations which are implemented for Atmosphere(0). They are not necessary for a successful Atmosphere(1) deployment.</p>
+              <h4 id="elk">ELK</h4>
+              <p><a href="http://logz.io/learn/complete-guide-elk-stack/">ELK stack</a> (Elasticsearch, Logstash, Kibana) handles logging information from Atmosphere-Ansible.</p>
+              <h4 id="new-relic">New Relic</h4>
+              <h4 id="sentry">Sentry</h4>
+              <p>???</p>
+              <h3 id="openstack">OpenStack</h3>
+              <p>Atmosphere(1) is intended to be agnostic of cloud provider type, but all current deployments use OpenStack as the cloud provider back-end. OpenStack is a collection of projects which, together, provide infrastructure-as-a-service or a ‘cloud’.</p>
+              <h3 id="remote-access-methods">Remote Access Methods</h3>
+              <p>Atmosphere(1) supports several means of users accessing their instances.</p>
+              <h4 id="ssh">SSH</h4>
+              <p>Users can create a secure shell to their VMs directly over the internet, authenticating either with their Atmosphere(0) credentials or with an SSH keypair. Atmosphere(1) is essentially uninvolved in this workflow, though it provides a way for users to automatically install their public SSH key on new and re-deployed instances.</p>
+              <h4 id="web-shell">Web Shell</h4>
+              <p>Web Shell gets you a command line session in your browser, launched from the Troposphere UI. Web Shell uses <a href="https://liftoff.github.io/GateOne/About/index.html">Gate One</a>, a web-based terminal emulator. The Gate One server creates an SSH connection to the instance and exposes that shell to the user in a web interface, proxying the SSH traffic. For Atmosphere(0), the GateOne server is known as “bob” / “atmo-proxy”.</p>
+              <p>See <a href="/wiki/display/csmgmt/GateOne+Background">GateOne Background</a> (TODO migrate the content and fix this link) for detailed design and troubleshooting information.</p>
+              <h4 id="web-desktop">Web Desktop</h4>
+              <p>Web Desktop gets you a graphical desktop session in your browser, launched from the Troposphere UI. Web Desktop uses <a href="https://kanaka.github.io/noVNC">NoVNC</a>, a web-based VNC client. This is brokered through webaccess.cyverse.org.</p>
+              <p><a href="https://github.com/cyverse/nginx_novnc_auth" class="uri">https://github.com/cyverse/nginx_novnc_auth</a></p>
+              <p><a href="https://github.com/cyverse/clank/blob/master/playbooks/utils/install_novnc_auth.yml" class="uri">https://github.com/cyverse/clank/blob/master/playbooks/utils/install_novnc_auth.yml</a></p>
+              <h4 id="future-guacamole">Future: Guacamole</h4>
+              <p><a href="http://guacamole.incubator.apache.org/">Guacamole</a> is an HTML5 remote desktop gateway which provides both a command-line shell and a graphical desktop. Guacamole is planned as a replacement for Gate One and NoVNC, though this is not implemented in production yet.</p>
               <h2 id="clouds">Clouds</h2>
               <p>Atmosphere(0, 1, 2) provisions virtual machines on several ‘clouds’ which actually host the instances and computing infrastructure. Currently, all cloud providers use OpenStack. It is also possible for Atmosphere to provide access to commodity IaaS like Amazon Web Services (AWS), though this is not currently configured.</p>
               <h2 id="tools-and-workflows">Tools and Workflows</h2>

--- a/dist/contributing_to_atmosphere.html
+++ b/dist/contributing_to_atmosphere.html
@@ -103,7 +103,7 @@
               <p>Atmosphere or ‘atmo’ can refer to several different things:</p>
               <ul>
               <li><a href="https://atmo.cyverse.org/application">Atmosphere</a>(0), CyVerse’s “cloud computing for scientists” service</li>
-              <li><a href="/wiki/display/csmgmt/Atmosphere+Technology+Stack+Overview">Atmosphere</a>(1), <strong>the free, open-source software project</strong> which powers the above service (and is the primary focus of these guides) (TODO fix broken link)</li>
+              <li>Atmosphere(1), <strong>the free, open-source software project</strong> which powers the above service (and is the primary focus of these guides)</li>
               <li><a href="https://github.com/iPlantCollaborativeOpenSource/atmosphere">Atmosphere</a>(2), the API and back-end component of the above software project</li>
               </ul>
               <p>For clarity, this page will disambiguate all uses of “Atmosphere”.</p>
@@ -142,7 +142,7 @@
               <h2 id="resources-and-docs-for-new-contributors">Resources and Docs for New Contributors</h2>
               <p>Familiarize yourself with the following links and use them as a reference.</p>
               <ul>
-              <li><a href="/wiki/display/csmgmt/Atmosphere+Troubleshooting+Orientation">Atmosphere Troubleshooting Orientation</a> (TODO fix broken link)</li>
+              <li><a href="./troubleshooting_guide.html">Atmosphere Troubleshooting Guide</a></li>
               <li><a href="http://docs.atmospherev2.apiary.io/">Atmosphere(2) API docs on Apiary</a></li>
               </ul>
               <h2 id="key-terms">Key Terms</h2>
@@ -151,7 +151,7 @@
               <li><em>Instance</em>: a Virtual Machine (VM) or “cloud computer” running on Atmosphere(0) / OpenStack.</li>
               <li><em>Image:</em> a <a href="https://en.wikipedia.org/wiki/Disk_image">disk image</a> of a Virtual Machine (with some metadata) from which instances are created.</li>
               <li><em>Allocation</em>: the amount of “CPU time” that a user is allotted, measured in AUs (see below).</li>
-              <li><em>Allocation Unit</em> <em>(AU)</em>: “roughly equivalent to using one CPU-hour, or to using one CPU core for one hour.” (<a href="https://pods.iplantcollaborative.org/wiki/display/atmman/Requesting+More+Atmosphere+Resources">source</a>) (TODO fix broken link)</li>
+              <li><em>Allocation Unit</em> <em>(AU)</em>: “roughly equivalent to using one CPU-hour, or to using one CPU core for one hour.” (<a href="https://pods.iplantcollaborative.org/wiki/display/atmman/Requesting+More+Atmosphere+Resources">source</a>)</li>
               <li><em>Modal</em>: a <a href="https://en.wikipedia.org/wiki/Modal_window">modal window</a> in a GUI; the Troposphere UI uses these extensively.</li>
               </ul>
               <h2 id="technology-stack-overview">Technology Stack Overview</h2>
@@ -195,7 +195,7 @@
               <p>Users can create a secure shell to their VMs directly over the internet, authenticating either with their Atmosphere(0) credentials or with an SSH keypair. Atmosphere(1) is essentially uninvolved in this workflow, though it provides a way for users to automatically install their public SSH key on new and re-deployed instances.</p>
               <h4 id="web-shell">Web Shell</h4>
               <p>Web Shell gets you a command line session in your browser, launched from the Troposphere UI. Web Shell uses <a href="https://liftoff.github.io/GateOne/About/index.html">Gate One</a>, a web-based terminal emulator. The Gate One server creates an SSH connection to the instance and exposes that shell to the user in a web interface, proxying the SSH traffic. For Atmosphere(0), the GateOne server is known as “bob” / “atmo-proxy”.</p>
-              <p>See <a href="/wiki/display/csmgmt/GateOne+Background">GateOne Background</a> (TODO migrate the content and fix this link) for detailed design and troubleshooting information.</p>
+              <p>See <a href="/wiki/display/csmgmt/GateOne+Background">GateOne Background</a> (TODO fix this link once the content is migrated) for detailed design and troubleshooting information.</p>
               <h4 id="web-desktop">Web Desktop</h4>
               <p>Web Desktop gets you a graphical desktop session in your browser, launched from the Troposphere UI. Web Desktop uses <a href="https://kanaka.github.io/noVNC">NoVNC</a>, a web-based VNC client. This is brokered through webaccess.cyverse.org.</p>
               <p><a href="https://github.com/cyverse/nginx_novnc_auth" class="uri">https://github.com/cyverse/nginx_novnc_auth</a></p>

--- a/dist/index.html
+++ b/dist/index.html
@@ -52,6 +52,7 @@
               <li><a href="./install_guide.html">Install Guide</a></li>
               <li><a href="./connecting_cloud_provider.html">Connecting a Cloud Provider</a></li>
               <li><a href="./staff_guide.html">Staff Guide</a></li>
+              <li><a href="./troubleshooting_guide.html">Troubleshooting Guide</a></li>
               </ul>
               <h2 id="for-users">For Users</h2>
               <ul>

--- a/dist/index.html
+++ b/dist/index.html
@@ -61,7 +61,7 @@
               </ul>
               <h2 id="for-developers">For Developers</h2>
               <ul>
-              <li><a href=".contributing_to_atmosphere.html">Contributing to Atmosphere</a></li>
+              <li><a href="./contributing_to_atmosphere.html">Contributing to Atmosphere</a></li>
               </ul>
               </article>
             </div> <!-- #main -->

--- a/dist/index.html
+++ b/dist/index.html
@@ -35,20 +35,32 @@
                       <h3> TABLE OF CONTENTS </h3>
                       <ul>
                       <li><a href="#atmosphere-guides">Atmosphere Guides</a></li>
-                      <li><a href="#the-guides">The Guides</a></li>
+                      <li><a href="#the-guides">The Guides</a><ul>
+                      <li><a href="#for-site-operators">For Site Operators</a></li>
+                      <li><a href="#for-users">For Users</a></li>
+                      <li><a href="#for-developers">For Developers</a></li>
+                      </ul></li>
                       </ul>
                   </aside>
                               <!-- MAIN CONTENT -->
               <article>
               <h1 id="atmosphere-guides">Atmosphere Guides</h1>
-              <p>This site is intended to provide guides for how Atmosphere should be used. Both by End Users and by Staff and Support.</p>
+              <p>This site hosts documentation for Atmosphere, the free, open-source cloud computing project (as distinct from CyVerse’s “cloud computing for scientists” service). It is intended for both “site operators” (groups interested in operating/supporting their own Atmosphere deployment), users (very incomplete), and developers who are interested in contributing to the project.</p>
               <h1 id="the-guides">The Guides</h1>
+              <h2 id="for-site-operators">For Site Operators</h2>
               <ul>
               <li><a href="./install_guide.html">Install Guide</a></li>
               <li><a href="./connecting_cloud_provider.html">Connecting a Cloud Provider</a></li>
               <li><a href="./staff_guide.html">Staff Guide</a></li>
+              </ul>
+              <h2 id="for-users">For Users</h2>
+              <ul>
               <li><a href="./user_guide.html">User Guide</a></li>
               <li><a href="./imaging_guide.html">Imaging Guide</a></li>
+              </ul>
+              <h2 id="for-developers">For Developers</h2>
+              <ul>
+              <li><a href=".contributing_to_atmosphere.html">Contributing to Atmosphere</a></li>
               </ul>
               </article>
             </div> <!-- #main -->

--- a/dist/troubleshooting_guide.html
+++ b/dist/troubleshooting_guide.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang=""> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8" lang=""> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9" lang=""> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang=""> <!--<![endif]-->
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta http-equiv="Content-Style-Type" content="text/css" />
+        <meta name="generator" content="pandoc" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+                    <title></title>
+        <style type="text/css">code{white-space: pre;}</style>
+                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" type="text/css" />
+                    <link rel="icon" href="themes/cyverse/media/favicon.ico" type="image/x-icon">
+        <link rel="stylesheet" href="themes/cyverse/media/css/normalize.min.css">
+        <link rel="stylesheet" href="themes/cyverse/media/css/main.css">
+        <script src="themes/cyverse/media/js/vendor/modernizr-2.8.3-respond-1.4.2.min.js"></script>
+          </head>
+    <body>
+        <!--[if lt IE 8]>
+            <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+        <![endif]-->
+
+                <div class="header-container">
+            <header class="wrapper clearfix">
+                <div class="logo"><img src="themes/cyverse/media/cyverse_logo.png" alt="Staff Guide"></div>
+                <h1 class="title"></h1>
+            </header>
+        </div>
+        
+        <div class="main-container">
+            <div class="main wrapper clearfix">
+              <!-- TABLE OF CONTENTS -->
+                                  <aside>
+                      <h3> TABLE OF CONTENTS </h3>
+                      <ul>
+                      <li><a href="#atmosphere-troubleshooting-guide">Atmosphere Troubleshooting Guide</a><ul>
+                      <li><a href="#common-problems">Common Problems</a><ul>
+                      <li><a href="#my-instance-wont-deploy">My Instance Won’t Deploy</a></li>
+                      </ul></li>
+                      <li><a href="#troubleshooting-tools">Troubleshooting Tools</a><ul>
+                      <li><a href="#launching-instances-without-troposphere">Launching instances without Troposphere</a></li>
+                      <li><a href="#launching-instances-without-atmosphere-ansible">Launching Instances without atmosphere-ansible</a></li>
+                      <li><a href="#accessing-atmosphere-during-maintenance">Accessing Atmosphere During Maintenance</a></li>
+                      <li><a href="#emulating-another-atmosphere1-user">Emulating Another Atmosphere(1) User</a></li>
+                      <li><a href="#testing-deployments-against-multiple-distros">Testing Deployments Against Multiple Distros</a></li>
+                      <li><a href="#capturing-instance-details-for-problem-reports">Capturing Instance Details for Problem Reports</a></li>
+                      </ul></li>
+                      <li><a href="#logs">Logs</a><ul>
+                      <li><a href="#log-files-on-atmosphere-server">Log Files on Atmosphere server</a></li>
+                      <li><a href="#celery-flower">Celery Flower</a></li>
+                      </ul></li>
+                      </ul></li>
+                      </ul>
+                  </aside>
+                              <!-- MAIN CONTENT -->
+              <article>
+              <h1 id="atmosphere-troubleshooting-guide">Atmosphere Troubleshooting Guide</h1>
+              <p>Where to look and what to do when something is broken. See also <a href="/wiki/display/csmgmt/Taking+care+of+the+Atmosphere">Taking care of the Atmosphere</a> (TODO fix link), and <a href="/wiki/display/csmgmt/Atmosphere+Tips%2C+Troubleshooting%2C+Workarounds%2C+and+Solutions">Atmosphere Tips, Troubleshooting, Workarounds, and Solutions</a> (TODO fix link).</p>
+              <h2 id="common-problems">Common Problems</h2>
+              <h3 id="my-instance-wont-deploy">My Instance Won’t Deploy</h3>
+              <p>Check Atmosphere logs, Kibana, and Celery logs, to determine if the problem is with Atmosphere(2), the OpenStack cloud, or the Ansible code that is run during deployment.</p>
+              <p>Note that resuming a suspended instance also re-deploys it.</p>
+              <h2 id="troubleshooting-tools">Troubleshooting Tools</h2>
+              <h3 id="launching-instances-without-troposphere">Launching instances without Troposphere</h3>
+              <p>To launch instances via atmosphere (without the use of a GUI):</p>
+              <pre><code>#############1 - Setting up the environment ######################
+              # Ensure that PYTHONPATH and DJANGO_SETTINGS_MODULE are pointed to atmosphere:
+              export PYTHONPATH=/opt/dev/atmosphere:$PYTHONPATH
+              export DJANGO_SETTINGS_MODULE=atmosphere.settings
+              
+              #############2 - Getting the correct arguments ######################
+              # Run script with --provider-list to get providers to launch from:
+              # ./scripts/launch_instances.py --provider-list
+              # ID      Name
+              # 1       EUCALYPTUS
+              # 2       OPENSTACK
+              # 3       EC2_US_EAST
+              # 4       Jetstream - Indiana University
+              # 5       Jetstream - TACC
+              
+              # Run script with --provider-id + --size-list and select a size (by ID)
+              # ./scripts/launch_instances.py --size-list --provider-id 4
+              # ID      Name    CPU     Memory
+              # 1       m1.tiny 1       2048
+              # 2       m1.small        2       4096
+              # 3       m1.medium       6       16384
+              # 4       m1.large        10      30720
+              # 6       m1.xxlarge      44      122880
+              # 8       m1.xlarge       24      61440
+              # 30      m1.xlarge.paramtest     24      61440
+              
+              # Run script with --provider-id + --machine-list and select a machine (by alias)
+              # ./scripts/launch_instances.py --skip-deploy --users sgregory --size 3 --provider-id 4 --machine-list
+              # Instances Launched: 235 - 30f31162-2a7a-4ac5-be1a-45c7e579a04b (Provider:4:Jetstream - Indiana University - App:Ubuntu 14.04.3 Development GUI by jfischer - 2017-01-02 18:24:00+00:00 Version:Ubuntu 14.04.3 Development GUI - 1.3 - 2016-07-15 21:02:42.359171+00:00)
+              # Instances Launched: 156 - 28235434-a4b0-4f27-ad58-e5c3052576da (Provider:4:Jetstream - Indiana University - App:CentOS 6 (6.8) Development GUI by jfischer - 2016-11-04 21:14:02+00:00 Version:CentOS 6 (6.8) Development GUI - 1.5 - 2016-04-01 18:22:33.843209+00:00)
+              # Instances Launched: 264 - 01fb694b-a58c-46b2-8744-99e177f6ea34 (Provider:4:Jetstream - Indiana University - App:MAKER 2.31.8 with CCTools by upendra - 2017-01-19 18:08:58+00:00 Version:MAKER 2.31.8 with CCTools - 1.0 - END-DATED)
+              # Instances Launched: 118 - 5ad04c2a-1503-4b44-9f5a-ad0abde2a685 (Provider:4:Jetstream - Indiana University - App:I435-I535-B669 Project B by atmoadmin - 2016-11-11 19:41:09+00:00 Version:I435-I535-B669 Project B - 1.0 - 2016-11-11 15:15:06.345665+00:00)
+              # Instances Launched: 93 - dbfe6ffa-084f-411d-bde4-676d4ca4da0f (Provider:4:Jetstream - Indiana University - App:CentOS 7 Development by jfischer - END-DATED Version:CentOS 7 Development - 1.1 - END-DATED)
+              # Instances Launched: 103 - 1c997f2c-bae9-4b53-9197-2948cd449405 (Provider:4:Jetstream - Indiana University - App:Ubuntu 14.04.3 Trusty Tahr by admin - END-DATED Version:Ubuntu 14.04.3 Trusty Tahr - 1.0 - END-DATED)
+              # Instances Launched: 159 - d1126e09-9e87-4f88-914f-fa42ba256c68 (Provider:4:Jetstream - Indiana University - App:BioLinux 8 by jfischer - 2017-01-24 17:25:40+00:00 Version:BioLinux 8 - 1.0 - 2016-03-29 21:38:14.409121+00:00)
+              # Instances Launched: 320 - fcc8542f-1b06-4d51-80c9-c8a505bc6eff (Provider:4:Jetstream - Indiana University - App:I535-I435-B669 Project A by luoyu - 2016-10-26 18:08:35+00:00 Version:I535-I435-B669 Project A - 1.0 - 2016-09-21 19:27:05.396602+00:00)
+              # Instances Launched: 98 - 3c3db94e-377b-4583-83d7-082d1024d74a (Provider:4:Jetstream - Indiana University - App:Ubuntu 14.04.3 Development by jfischer - END-DATED Version:Ubuntu 14.04.3 Development - 1.1 - 2016-05-24 18:00:30.333275+00:00)
+              # Instances Launched: 152 - bd81558e-9ba9-495e-a82c-4fbfc278a5ee (Provider:4:Jetstream - Indiana University - App:Ubuntu 14.04.3 Development GUI by jfischer - 2017-01-02 18:24:00+00:00 Version:Ubuntu 14.04.3 Development GUI - 1.1-stable - 2016-04-13 17:11:44.783177+00:00)
+              
+              #############3 - Launching the instance ######################
+              ./scripts/launch_instances.py --users sgregory --size 3 --provider-id 4 --machine-alias 66322719-5bfa-4646-93c6-0132e9a958e5 --name sgregory-testlaunch
+              Using Username sgregory.
+              Using Provider 4:Jetstream - Indiana University.
+              Using Size m1.medium.
+              .... Logging output for debug purposes
+              ....
+              Successfully launched Machine 66322719-5bfa-4646-93c6-0132e9a958e5 : 2e90c453-7509-4442-ae28-405b4aaeca10 (Name:sgregory-testlaunch 1, Creator:sgregory, IP:0.0.0.0)
+              Launched 1 instances.</code></pre>
+              <h3 id="launching-instances-without-atmosphere-ansible">Launching Instances without atmosphere-ansible</h3>
+              <p>Sometimes it is useful to be able to launch instances, add their floating IP, but <strong>skip the ansible portion</strong> of instance deployment. As it turns out, the script above is perfect for this! simply include the flag <code>--skip-deploy</code> to <strong>./scripts/launch_instances.py</strong> in addition to the standard arguments and environment setup described in the section above.</p>
+              <pre><code>#############1 - Setting up the environment ######################
+              See above
+              #############2 - Getting the correct arguments ######################
+              See above
+              #############3 - Launching the instance ######################
+              ./scripts/launch_instances.py --skip-deploy --users sgregory --size 3 --provider-id 4 --machine-alias 66322719-5bfa-4646-93c6-0132e9a958e5 --name sgregory-test-nodeploy
+              Using Username sgregory.
+              Using Provider 4:Jetstream - Indiana University.
+              Using Size m1.medium.
+              .... Logging output for debug purposes
+              ....
+              Successfully launched Machine 66322719-5bfa-4646-93c6-0132e9a958e5 : 2e90c453-7509-4442-ae28-405b4aaeca10 (Name:sgregory-test-nodeploy 1, Creator:sgregory, IP:0.0.0.0)
+              Launched 1 instances.
+              
+              ## When you decide you would later like to run ansible by hand, via the REPL:
+              from service.deploy import instance_deploy
+              instance_deploy(...)</code></pre>
+              <h3 id="accessing-atmosphere-during-maintenance">Accessing Atmosphere During Maintenance</h3>
+              <p>There is an “exception” URI to access the UI when Atmosphere is in maintenance mode.</p>
+              <p>Browse to <a>https://(atmosphere-url)/application_backdoor.</a></p>
+              <p>In order to access the backdoor, you will need to be included in <a href="https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/troposphere/settings/local.py.j2#L41-L43"><code>STAFF_LIST_USERNAMES</code></a> . This is set in the variables.yml (build env) for a deployed environment (dev, beta, prod). Using Jinja2 syntax for referring to YAML data structures, within the build env <code>variables.yml</code> file, the list is <code>TROPO['local.py']['STAFF_LIST_USERNAME']</code>.</p>
+              <p>Or:</p>
+              <pre>TROPO:
+                  local.py:
+                      STAFF_LIST_USERNAME: ['cmart', 'lenards']</pre>
+              <h3 id="emulating-another-atmosphere1-user">Emulating Another Atmosphere(1) User</h3>
+              <p>If you have a staff account in Atmosphere (i.e. you see the “admin” section in Troposphere), you can become (“emulate”) another user account. Browse to https://(atmosphere-url)/application/emulate/(username), replacing (atmosphere-url) as appropriate, and (username) with the user you want to emulate. To clear an emulated session, navigate to https://(atmosphere-url)/application/emulate.</p>
+              <h3 id="testing-deployments-against-multiple-distros">Testing Deployments Against Multiple Distros</h3>
+              <p>See <a href="https://pods.iplantcollaborative.org/wiki/display/csmgmt/Ansible+Deployment#AnsibleDeployment-Images/AccountstotestAnsible">Images/Accounts to test Ansible</a> (TODO fix link) for a list of images known to work for various distros.</p>
+              <h3 id="capturing-instance-details-for-problem-reports">Capturing Instance Details for Problem Reports</h3>
+              <p>You can easily capture critical information about an instance in order to include it in a problem report. Click on the gravatar (icon), and a string will be printed to your browser’s developer tools console in the following format:</p>
+              <pre><code>&lt;image-name&gt; - &lt;instance-GUID&gt; - &lt;provider&gt; - &lt;ip-address&gt; - &lt;deploy-date-time&gt;</code></pre>
+              <h2 id="logs">Logs</h2>
+              <h3 id="log-files-on-atmosphere-server">Log Files on Atmosphere server</h3>
+              <p>Atmosphere(1) writes logs to several places:</p>
+              <ul>
+              <li>Nginx logs in /var/log/nginx</li>
+              <li>uWSGI logs in /var/log/uwsgi/app (atmosphere.log and troposphere.log)</li>
+              <li>“Internal server error” messages usually point to an error here.</li>
+              <li>Django logs in /opt/dev/atmosphere/logs</li>
+              <li>Celery logs in /var/log/celery</li>
+              <li>atmosphere-ansible run logs in /opt/dev/atmosphere/logs/atmosphere_deploy.log</li>
+              </ul>
+              <h3 id="celery-flower">Celery Flower</h3>
+              <p><a href="https://flower.readthedocs.io/en/latest/">Flower</a> is installed for monitoring Celery tasks (e.g. running Ansible against new instances). Browse to https://(atmosphere-url)/flower. The authentication scheme and credentials are set in clank’s variables.yml at deploy time.</p>
+              </article>
+            </div> <!-- #main -->
+        </div> <!-- #main-container -->
+
+                <div class="footer-container">
+            <footer class="wrapper">
+                    <footer class="footer"> <!-- Needs to be a `include-after` -->
+          		<div class="container">
+          		  <div class="region region-footer">
+          		    <section id="block-block-25" class="block block-block clearfix">
+          		      <p><img alt="Cyverse" src="./media/cyverse_icon_transp2.png" style="width: 25px; height: 24px;">&nbsp;<a href="http://www.cyverse.org/">CyVerse</a> | <a href="http://www.cyverse.org/open-source">Open Source</a> | <img alt="NSF" src="./media/nsf1.gif" style="width: 25px; height: 25px;">&nbsp;</p>
+          		    </section>
+          		  </div>
+          		</div>
+        	    </footer>
+            </footer>
+        </div>
+        <!-- Included at the end of body -->
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+        <script>window.jQuery || document.write('<script src="themes/cyverse/media/js/vendor/jquery-1.11.2.min.js"><\/script>')</script>
+        
+        <script src="themes/cyverse/media/js/main.js"></script>
+            </body>
+</html>

--- a/dist/troubleshooting_guide.html
+++ b/dist/troubleshooting_guide.html
@@ -56,7 +56,7 @@
                               <!-- MAIN CONTENT -->
               <article>
               <h1 id="atmosphere-troubleshooting-guide">Atmosphere Troubleshooting Guide</h1>
-              <p>Where to look and what to do when something is broken. See also <a href="/wiki/display/csmgmt/Taking+care+of+the+Atmosphere">Taking care of the Atmosphere</a> (TODO fix link), and <a href="/wiki/display/csmgmt/Atmosphere+Tips%2C+Troubleshooting%2C+Workarounds%2C+and+Solutions">Atmosphere Tips, Troubleshooting, Workarounds, and Solutions</a> (TODO fix link).</p>
+              <p>Where to look and what to do when something is broken.</p>
               <h2 id="common-problems">Common Problems</h2>
               <h3 id="my-instance-wont-deploy">My Instance Won’t Deploy</h3>
               <p>Check Atmosphere logs, Kibana, and Celery logs, to determine if the problem is with Atmosphere(2), the OpenStack cloud, or the Ansible code that is run during deployment.</p>

--- a/src/contributing_to_atmosphere/contributing_to_atmosphere.md
+++ b/src/contributing_to_atmosphere/contributing_to_atmosphere.md
@@ -26,6 +26,8 @@ Atmosphere(1) is deployed at CyVerse as Atmosphere(0), but also at several other
 
 ### Repositories on Github
 
+(Should we make this a table of repo + link + purpose?)
+
 - [atmosphere](https://github.com/iplantcollaborativeopensource/atmosphere)(2), and supporting projects:
     - [django-iplant-auth](https://github.com/iPlantCollaborativeOpenSource/django-iplant-auth) (used by Django backends of Atmosphere & Troposphere)
     -  [subspace](https://github.com/iPlantCollaborativeOpenSource/subspace) (runs the Ansible for instance deploys)
@@ -43,7 +45,6 @@ Atmosphere(1) is deployed at CyVerse as Atmosphere(0), but also at several other
 - [ansible-gateone-server](https://github.com/cyverse/atmosphere-guides)
 - [atmosphere-guides](https://github.com/cyverse/atmosphere-guides) documentation for Atmosphere(1)
 
-
 ## Resources and Docs for New Contributors
 
 Familiarize yourself with the following links and use them as a reference.
@@ -51,8 +52,6 @@ Familiarize yourself with the following links and use them as a reference.
 - [Atmosphere Technology Stack Overview](/wiki/display/csmgmt/Atmosphere+Technology+Stack+Overview) (TODO fix broken link)
 - [Atmosphere Troubleshooting Orientation](/wiki/display/csmgmt/Atmosphere+Troubleshooting+Orientation) (TODO fix broken link)
 - [Atmosphere(2) API docs on Apiary](http://docs.atmospherev2.apiary.io/)
-- [Atmosphere Staff Manual](/wiki/display/csmgmt/Atmosphere+Staff+Manual) containing information on releases  (TODO fix broken link, incorporate that stuff here)
-- [Approach to tagging releases](/wiki/display/csmgmt/Approach+to+tagging+releases) (TODO fix broken link)
 
 ## Key Terms
 
@@ -63,56 +62,6 @@ You'll hear these a lot on the Atmosphere project:
 - _Allocation_: the amount of "CPU time" that a user is allotted, measured in AUs (see below).
 - _Allocation Unit_ _(AU)_: "roughly equivalent to using one CPU-hour, or to using one CPU core for one hour." ([source](https://pods.iplantcollaborative.org/wiki/display/atmman/Requesting+More+Atmosphere+Resources)) (TODO fix broken link)
 - _Modal_: a [modal window](https://en.wikipedia.org/wiki/Modal_window) in a GUI; the Troposphere UI uses these extensively.
-
-## Testing and Deployment Workflows
-
-### How Atmosphere is Tested
-
-The stack is tested at various levels; test coverage and the testing process is a work in progress.
-
-#### Django tests in Atmosphere(2)
-
-Unit tests written by developers can be found throughout the codebase. These tests are not currently running as part of regular build/deploy workflow, but we could!
-
-#### [Travis CI](https://travis-ci.org/) running style & bundle/compile tests for Troposphere
-
-- see [.travis.yml](https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/.travis.yml) in Troposphere for configuration
-- [Troposphere test results on Travis CI](https://travis-ci.org/iPlantCollaborativeOpenSource/troposphere)
-
-#### QA Team tests using Robot Framework and JMeter
-
-Note that the following information describes processes performed by the QA Team at CyVerse who primarily support Atmosphere(0), but their effort certainly also benefits Atmosphere(1). This team is also responsible for testing other CyVerse products (e.g. Discovery Environment). Some resources described in this section are currently only accessiblt to members of CyVerse staff.
-
-Tests are built based on QA team using and reverse engineering Atmosphere(1) on atmobeta.cyverse.org, and the history of internal JIRA issues. QA team does not currently receive product specifications or release notes.
-
-Individual tests are tagged in a few dimensions:
-
-- Type of test
-    - Smoke tests, which confirm very basic communication/functionality/existence of API and UI objects
-    - Functional tests, which confirm the actual functioning ("golden path") of API endpoints and UI objects
-    - Regression tests, which confirm that resolved issues do not recur and pushes boundaries
-- Layer of stack under test
-    - Atmosphere(2) API (HTTP calls using curl)
-    - Troposphere UI (browser driven with Selenium)
-
-atmobeta.cyverse.org is tested nightly, and test results can be found on [https://shimerdas.iplantcollaborative.org:8443](https://shimerdas.iplantcollaborative.org:8443). (You must be a member of CyVerse staff and on an internal network to access shimerdas Jenkins server.) Only atmobeta is targeted during _regression_ testing.
-
-atmo-dev.cyverse.org is tested as part of each continuous deployment. Jenkins runs tests against atmo-dev in two jobs (these links are only accessible to CyVerse staff):
-
-- [Test_Atmosphere](https://atmo-dev.cyverse.org/jenkins/job/Test_Atmosphere/) (API tests)
-- [Test_Troposphere](https://atmo-dev.cyverse.org/jenkins/job/Test_Troposphere/) (GUI tests)
-
-Test coverage is greater for the Atmosphere(2) API than for the Troposphere UI. QA team's tests do not currently confirm that instances launch, nor do they execute the various instance access workflows (e.g. Web Shell and Web Desktop), but it is possible for this coverage to be added.
-
-If a test fails repeatedly, QA team files a JIRA ticket, tags the test with the JIRA number, and disables that test until the issue is resolved.
-
-More information on the QA team's work can be found on [qa-4.cyverse.org](http://qa-4.cyverse.org), including the [automated test suites](http://qa-4.cyverse.org/Atmosphere/) and how to run test suites locally ([1](http://qa-4.cyverse.org/robotframework/misc/html/RobotFramework_and_iPlant.txt), [2](http://qa-4.cyverse.org/robotframework/misc/html/RobotFramework_Setup_for_iPlant-OLD.txt)). (Only accessible to CyVerse staff.) Note that much of the information is for other CyVerse projects, and some test framework dependencies are unnecessary if you are only testing Atmosphere.
-
-#### [Operation Sanity](https://github.com/cyverse/operation-sanity) behavioral testing
-
-Operation Sanity is a set of test suites written using behave, which drive a browser using Selenium. Operation Sanity exercises common Atmosphere workflows as a user: launches several instances against multiple cloud providers, ensures that those instances launch, creates and attaches volumes, and so forth. It is intended to run these tests in parallel so that long operations (e.g. waiting for an instance to launch) do not block execution.
-
-Operation Sanity is currently in a "proof of concept" state, and is currently not run automatically. There is some intended functionality (e.g. testing launch of Web Shell and Web Desktop) which needs to be built.
 
 ## Clouds
 
@@ -159,3 +108,136 @@ Forward-facing projects that are critical to Atmosphere(1) have designated point
 - [Troposphere](https://github.com/iPlantCollaborativeOpenSource/troposphere): [Andrew Lenards](https://github.com/lenards)
 
 Ancillary projects have a wider set of individuals with write access, these are typically members of the Atmosphere(0) team at CyVerse.
+
+## How Atmosphere is Tested
+
+The stack is tested at various levels; test coverage and the testing process is a work in progress.
+
+### Django tests in Atmosphere(2)
+
+Unit tests written by developers can be found throughout the codebase. These tests are not currently running as part of regular build/deploy workflow, but we could!
+
+### [Travis CI](https://travis-ci.org/) running style & bundle/compile tests for Troposphere
+
+- see [.travis.yml](https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/.travis.yml) in Troposphere for configuration
+- [Troposphere test results on Travis CI](https://travis-ci.org/iPlantCollaborativeOpenSource/troposphere)
+
+### QA Team tests using Robot Framework and JMeter
+
+Note that the following information describes processes performed by the QA Team at CyVerse who primarily support Atmosphere(0), but their effort certainly also benefits Atmosphere(1). This team is also responsible for testing other CyVerse products (e.g. Discovery Environment). Some resources described in this section are currently only accessiblt to members of CyVerse staff.
+
+Tests are built based on QA team using and reverse engineering Atmosphere(1) on atmobeta.cyverse.org, and the history of internal JIRA issues. QA team does not currently receive product specifications or release notes.
+
+Individual tests are tagged in a few dimensions:
+
+- Type of test
+    - Smoke tests, which confirm very basic communication/functionality/existence of API and UI objects
+    - Functional tests, which confirm the actual functioning ("golden path") of API endpoints and UI objects
+    - Regression tests, which confirm that resolved issues do not recur and pushes boundaries
+- Layer of stack under test
+    - Atmosphere(2) API (HTTP calls using curl)
+    - Troposphere UI (browser driven with Selenium)
+
+atmobeta.cyverse.org is tested nightly, and test results can be found on [https://shimerdas.iplantcollaborative.org:8443](https://shimerdas.iplantcollaborative.org:8443). (You must be a member of CyVerse staff and on an internal network to access shimerdas Jenkins server.) Only atmobeta is targeted during _regression_ testing.
+
+atmo-dev.cyverse.org is tested as part of each continuous deployment. Jenkins runs tests against atmo-dev in two jobs (these links are only accessible to CyVerse staff):
+
+- [Test_Atmosphere](https://atmo-dev.cyverse.org/jenkins/job/Test_Atmosphere/) (API tests)
+- [Test_Troposphere](https://atmo-dev.cyverse.org/jenkins/job/Test_Troposphere/) (GUI tests)
+
+Test coverage is greater for the Atmosphere(2) API than for the Troposphere UI. QA team's tests do not currently confirm that instances launch, nor do they execute the various instance access workflows (e.g. Web Shell and Web Desktop), but it is possible for this coverage to be added.
+
+If a test fails repeatedly, QA team files a JIRA ticket, tags the test with the JIRA number, and disables that test until the issue is resolved.
+
+More information on the QA team's work can be found on [qa-4.cyverse.org](http://qa-4.cyverse.org), including the [automated test suites](http://qa-4.cyverse.org/Atmosphere/) and how to run test suites locally ([1](http://qa-4.cyverse.org/robotframework/misc/html/RobotFramework_and_iPlant.txt), [2](http://qa-4.cyverse.org/robotframework/misc/html/RobotFramework_Setup_for_iPlant-OLD.txt)). (Only accessible to CyVerse staff.) Note that much of the information is for other CyVerse projects, and some test framework dependencies are unnecessary if you are only testing Atmosphere.
+
+### [Operation Sanity](https://github.com/cyverse/operation-sanity) behavioral testing
+
+Operation Sanity is a set of test suites written using behave, which drive a browser using Selenium. Operation Sanity exercises common Atmosphere workflows as a user: launches several instances against multiple cloud providers, ensures that those instances launch, creates and attaches volumes, and so forth. It is intended to run these tests in parallel so that long operations (e.g. waiting for an instance to launch) do not block execution.
+
+Operation Sanity is currently in a "proof of concept" state, and is currently not run automatically. There is some intended functionality (e.g. testing launch of Web Shell and Web Desktop) which needs to be built.
+
+## Releases and Development Cycles
+
+You can see a list of releases as branches in each GitHub repository, e.g. [Atmosphere(2)](https://github.com/cyverse/atmosphere/branches).
+
+### Release Naming
+
+Name should be two words, a hyphen will be added between them. Hyphenated bird names used to be the golden ticket (Abyssinian-nightjar,california-condor) but we now allow for alliterative adjective/verb and bird name combinations (ex: jamming-junglefowl, mystifying-merlin, nautical-nighthawk). Helpful Link: [Birds Beginning with Letters](http://thewebsiteofeverything.com/animals/birds/beginning-with/A)
+
+### Approach to Tagging Releases
+In order to identify which release a repository is associated with, we need to "tag", or annotate, the association. Currently, we name branches by release for Atmosphere & Troposphere. However, there are dependencies in the instance deployment automation managed in Atmosphere-Ansible repository. This repo is used by "subspace" via Atmosphere API - yet, we are not explicitly denoting the Atmosphere-Ansible tested, verified, and deployed with an Atmosphere release.
+
+I suggest that we use ["annotated-tags"](https://git-scm.com/book/en/v2/Git-Basics-Tagging#Annotated-Tags) over lightweight tags; this allows for a "tag name" and a message.
+
+Given that we use letter-based alliterations for release names, I suggest was use a two-digit year plus letter initials as our _annotation_. So, petrified-penguin would be 16.p-p as the initial release. If there was patches applied to release, then it would be incremental:
+
+- 16-p-p-1
+- 16-p-p-2
+- 16-q-q
+- 16-q-q-1
+- 16-r-r
+- 16-r-r-1
+- 16-r-r-2
+- 16-s-s
+- 16-t-t
+- 17-u-u
+- 17-u-u-1
+- 17-v-v
+- 17-v-v-1
+
+Applying an annotated tag to a repository would allow a tag-name and a message. We'd then push to the origin without specifying a branch:
+
+```
+GIT_TAG="16-s-s"
+git tag -a $GIT_TAG -m "Solitary-Snipe released." && git push origin --tags</pre>
+```
+
+#### Note on "Sequence"
+
+The tag-name should be "two-digit" year concatenated with "release initials" (ravenous-raven shortens to r-r). Only add an incremented integer if more than one tag for a release is needed.
+
+#### What Should Be Tagged?
+
+The repositories that **should** be tagged for a release are as follows:
+
+- Atmosphere (<<release-name>> branch) - [repo](https://github.com/iPlantCollaborativeOpenSource/atmosphere)
+- Troposphere (<<release-name>> branch) - [repo](https://github.com/iPlantCollaborativeOpenSource/troposphere)
+- Atmosphere-Ansible (master) - [repo](https://github.com/iPlantCollaborativeOpenSource/atmosphere-ansible)
+- Clank (master - maybe a feature-branch) - [repo](https://github.com/iPlantCollaborativeOpenSource/clank)
+- nginx_novnc_auth (master) - [repo](https://github.com/cyverse/nginx_novnc_auth)
+
+We should consider tagging this fork
+- [https://github.com/edwins/gateone](https://github.com/edwins/gateone)
+
+### Release Structure
+
+The structure of releases is inspired by [Chrome/Chromium](http://blog.assembla.com/AssemblaBlog/tabid/12618/bid/36341/Secrets-of-rapid-release-cycles-from-the-Google-Chrome-team.aspx). We aim to deliver new code to production every 5 weeks. Those 5 weeks are split into 3 sprints (2 sprints of 2-weeks and a single 1-week sprint).
+
+#### First 2-week Sprint
+- new feature development
+- upgrading dependencies
+- testing/verification
+
+#### Second 2-week Sprint
+- Priority bug fixes
+- feature development _continued_
+- testing/verification
+
+#### Third 1-week Sprint
+- Any committed works left to finish
+- Priority/Critical tickets
+- testing/verification
+
+### Code Branching Strategy
+(Note that the following section contains links to environments that are only accessible to members of CyVerse staff.)
+
+The master branch collects new feature development and community contributions. [http://atmo-dev.cyverse.org](http://atmo-dev.cyverse.org) generally tracks master. Other feature branches are used as needed.
+
+The 'beta' / 'next release' branch collects stability improvements and bug fixes; it does not typically receive new features. [http://atmobeta.cyverse.org](http://atmobeta.cyverse.org/) generally tracks the next release.
+
+Think of each five-week cycle as an effort to 1. develop new features on the master branch, and 2. stabilize the beta/release branch for deployment to production.
+
+Bug fixes and other changes are regularly "trickled down" from the beta/release branch to the master branch, and when necessary, from production systems to beta/release.
+
+Following each release, any changes in the release branch are merged back into master. Then, master is branched into the 'next release' and the cycle repeats.

--- a/src/contributing_to_atmosphere/contributing_to_atmosphere.md
+++ b/src/contributing_to_atmosphere/contributing_to_atmosphere.md
@@ -1,0 +1,161 @@
+# Contributing to Atmosphere
+
+This page is recovering from major surgery (Atmosphere(0)-related content was left on the CyVerse wiki). The broken links will be fixed soon.
+
+This guide is intended to orient community members who are interested in contributing to Atmosphere. Welcome to the project!
+
+## What is Atmosphere?
+
+Atmosphere or 'atmo' can refer to several different things:
+
+- [Atmosphere](https://atmo.cyverse.org/application)(0), CyVerse's "cloud computing for scientists" service
+- [Atmosphere](/wiki/display/csmgmt/Atmosphere+Technology+Stack+Overview)(1), **the free, open-source software project** which powers the above service (and is the primary focus of these guides) (TODO fix broken link)
+- [Atmosphere](https://github.com/iPlantCollaborativeOpenSource/atmosphere)(2), the API and back-end component of the above software project
+
+For clarity, this page will disambiguate all uses of "Atmosphere".
+
+## Where is Atmosphere Deployed?
+
+Atmosphere(1) is deployed at CyVerse as Atmosphere(0), but also at several other organizations known by different names:
+
+- [Jetstream Cloud](http://jetstream-cloud.org/) (partnership of Indiana University, TACC, & CyVerse - Jetstream GitHub Organization: [jetstream-cloud](https://github.com/jetstream-cloud))
+- MOC (Massechusetts Open Cloud) (Jonathan Bell: [github-profile](https://github.com/lokI8), Lucas H. Xu: [github-profile](https://github.com/xuhang57))
+- Duke University / Duke Center for Genomic & Computational Biology ([Duke GCB](https://github.com/Duke-GCB)) (Darren Boss: [gcb-profile](https://genome.duke.edu/directory/gcb-staff/darren-boss); [github-profile](https://github.com/netscruff))
+
+## Where is the Code?
+
+### Repositories on Github
+
+- [atmosphere](https://github.com/iplantcollaborativeopensource/atmosphere)(2), and supporting projects:
+    - [django-iplant-auth](https://github.com/iPlantCollaborativeOpenSource/django-iplant-auth) (used by Django backends of Atmosphere & Troposphere)
+    -  [subspace](https://github.com/iPlantCollaborativeOpenSource/subspace) (runs the Ansible for instance deploys)
+    - [rtwo](https://github.com/iPlantCollaborativeOpenSource/rtwo)
+    - [chromogenic](https://github.com/iPlantCollaborativeOpenSource/chromogenic) (Imaging using in Atmosphere)
+    - [threepio](https://github.com/jmatt/threepio) (will be replaced as Django logging has improved since it was created)
+    - [atmosphere-v2-apiary-docs](https://github.com/iPlantCollaborativeOpenSource/atmosphere-v2-apiary-docs), some API documentation?
+    - [atmosphere-apiary-docs](https://github.com/iPlantCollaborativeOpenSource/atmosphere-apiary-docs), some old API documentation?
+- [troposphere](https://github.com/iplantcollaborativeopensource/troposphere), and supporting projects:
+    - [troposphere-ui,](https://github.com/cyverse/troposphere-ui) soon to be used by Troposphere
+- [atmosphere-ansible](https://github.com/iPlantCollaborativeOpenSource/atmosphere-ansible)
+- [clank](https://github.com/iPlantCollaborativeOpenSource/clank), Ansible-based automation which deploys Atmosphere(1)
+- [nginx_novnc_auth](https://github.com/cyverse/nginx_novnc_auth)
+- [edwins/GateOne](https://github.com/edwins/GateOne)
+- [ansible-gateone-server](https://github.com/cyverse/atmosphere-guides)
+- [atmosphere-guides](https://github.com/cyverse/atmosphere-guides) documentation for Atmosphere(1)
+
+
+## Resources and Docs for New Contributors
+
+Familiarize yourself with the following links and use them as a reference.
+
+- [Atmosphere Technology Stack Overview](/wiki/display/csmgmt/Atmosphere+Technology+Stack+Overview) (TODO fix broken link)
+- [Atmosphere Troubleshooting Orientation](/wiki/display/csmgmt/Atmosphere+Troubleshooting+Orientation) (TODO fix broken link)
+- [Atmosphere(2) API docs on Apiary](http://docs.atmospherev2.apiary.io/)
+- [Atmosphere Staff Manual](/wiki/display/csmgmt/Atmosphere+Staff+Manual) containing information on releases  (TODO fix broken link, incorporate that stuff here)
+- [Approach to tagging releases](/wiki/display/csmgmt/Approach+to+tagging+releases) (TODO fix broken link)
+
+## Key Terms
+
+You'll hear these a lot on the Atmosphere project:
+
+- _Instance_: a Virtual Machine (VM) or "cloud computer" running on Atmosphere(0) / OpenStack.
+- _Image:_ a [disk image](https://en.wikipedia.org/wiki/Disk_image) of a Virtual Machine (with some metadata) from which instances are created.
+- _Allocation_: the amount of "CPU time" that a user is allotted, measured in AUs (see below).
+- _Allocation Unit_ _(AU)_: "roughly equivalent to using one CPU-hour, or to using one CPU core for one hour." ([source](https://pods.iplantcollaborative.org/wiki/display/atmman/Requesting+More+Atmosphere+Resources)) (TODO fix broken link)
+- _Modal_: a [modal window](https://en.wikipedia.org/wiki/Modal_window) in a GUI; the Troposphere UI uses these extensively.
+
+## Testing and Deployment Workflows
+
+### How Atmosphere is Tested
+
+The stack is tested at various levels; test coverage and the testing process is a work in progress.
+
+#### Django tests in Atmosphere(2)
+
+Unit tests written by developers can be found throughout the codebase. These tests are not currently running as part of regular build/deploy workflow, but we could!
+
+#### [Travis CI](https://travis-ci.org/) running style & bundle/compile tests for Troposphere
+
+- see [.travis.yml](https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/.travis.yml) in Troposphere for configuration
+- [Troposphere test results on Travis CI](https://travis-ci.org/iPlantCollaborativeOpenSource/troposphere)
+
+#### QA Team tests using Robot Framework and JMeter
+
+Note that the following information describes processes performed by the QA Team at CyVerse who primarily support Atmosphere(0), but their effort certainly also benefits Atmosphere(1). This team is also responsible for testing other CyVerse products (e.g. Discovery Environment). Some resources described in this section are currently only accessiblt to members of CyVerse staff.
+
+Tests are built based on QA team using and reverse engineering Atmosphere(1) on atmobeta.cyverse.org, and the history of internal JIRA issues. QA team does not currently receive product specifications or release notes.
+
+Individual tests are tagged in a few dimensions:
+
+- Type of test
+    - Smoke tests, which confirm very basic communication/functionality/existence of API and UI objects
+    - Functional tests, which confirm the actual functioning ("golden path") of API endpoints and UI objects
+    - Regression tests, which confirm that resolved issues do not recur and pushes boundaries
+- Layer of stack under test
+    - Atmosphere(2) API (HTTP calls using curl)
+    - Troposphere UI (browser driven with Selenium)
+
+atmobeta.cyverse.org is tested nightly, and test results can be found on [https://shimerdas.iplantcollaborative.org:8443](https://shimerdas.iplantcollaborative.org:8443). (You must be a member of CyVerse staff and on an internal network to access shimerdas Jenkins server.) Only atmobeta is targeted during _regression_ testing.
+
+atmo-dev.cyverse.org is tested as part of each continuous deployment. Jenkins runs tests against atmo-dev in two jobs (these links are only accessible to CyVerse staff):
+
+- [Test_Atmosphere](https://atmo-dev.cyverse.org/jenkins/job/Test_Atmosphere/) (API tests)
+- [Test_Troposphere](https://atmo-dev.cyverse.org/jenkins/job/Test_Troposphere/) (GUI tests)
+
+Test coverage is greater for the Atmosphere(2) API than for the Troposphere UI. QA team's tests do not currently confirm that instances launch, nor do they execute the various instance access workflows (e.g. Web Shell and Web Desktop), but it is possible for this coverage to be added.
+
+If a test fails repeatedly, QA team files a JIRA ticket, tags the test with the JIRA number, and disables that test until the issue is resolved.
+
+More information on the QA team's work can be found on [qa-4.cyverse.org](http://qa-4.cyverse.org), including the [automated test suites](http://qa-4.cyverse.org/Atmosphere/) and how to run test suites locally ([1](http://qa-4.cyverse.org/robotframework/misc/html/RobotFramework_and_iPlant.txt), [2](http://qa-4.cyverse.org/robotframework/misc/html/RobotFramework_Setup_for_iPlant-OLD.txt)). (Only accessible to CyVerse staff.) Note that much of the information is for other CyVerse projects, and some test framework dependencies are unnecessary if you are only testing Atmosphere.
+
+#### [Operation Sanity](https://github.com/cyverse/operation-sanity) behavioral testing
+
+Operation Sanity is a set of test suites written using behave, which drive a browser using Selenium. Operation Sanity exercises common Atmosphere workflows as a user: launches several instances against multiple cloud providers, ensures that those instances launch, creates and attaches volumes, and so forth. It is intended to run these tests in parallel so that long operations (e.g. waiting for an instance to launch) do not block execution.
+
+Operation Sanity is currently in a "proof of concept" state, and is currently not run automatically. There is some intended functionality (e.g. testing launch of Web Shell and Web Desktop) which needs to be built.
+
+## Clouds
+
+Atmosphere(0, 1, 2) provisions virtual machines on several 'clouds' which actually host the instances and computing infrastructure. Currently, all cloud providers use OpenStack. It is also possible for Atmosphere to provide access to commodity IaaS like Amazon Web Services (AWS), though this is not currently configured.
+
+## Tools and Workflows
+
+### Common Technologies and Tools
+
+No matter your sub-specialty, you'll work with most/all of these as a member of the Atmosphere Team.
+
+- Python programming language, used for Atmosphere(2), Ansible, Subspace
+- Ansible, used for configuration management and infrastructure automation
+- YAML markup language, used for Ansible code and variables files
+- Markdown markup language, used for documentation
+- SSH, used for remotely accessing servers
+- git and Github, used for source control
+
+### Local Development Environment
+
+The local development environment-in-a-box is not yet published for community consumption. Coming soon!
+
+### Issue Tracking Systems
+
+The Atmosphere(0) team uses several internal systems to track development cycles and support issues. Unfortunately these are not accessible to community members. For now, please use the repository-specific Issues section in the appropriate GitHub repository (perhaps [atmosphere](https://github.com/cyverse/atmosphere)(2)) to report an issue with Atmosphere(1,2).
+
+If you are an Atmosphere(0) *user* seeking assistance and you ended up here for some reason, please log into [Atmosphere](https://atmo.cyverse.org/) and click the "Feedback & Support" link at the bottom of the page, or email support at cyverse dot org.
+
+### Contributing Code
+
+Note that the following information may change soon as the Atmosphere(0) team refines the development process for Atmosphere(1).
+
+#### On Github
+
+Most of Atmosphere(1)'s code lives on GitHub. Contributions to these codebases should follow a fork-and-pull-request workflow.
+
+1.  Create your own fork of the repository, work on the code there, test it in your local development environment
+2.  Create a pull request
+3.  Have someone else review and merge your pull request; ideally two people will review it.
+
+Forward-facing projects that are critical to Atmosphere(1) have designated point maintainers. Pull requests to these projects should be approved by the point maintainer when possible:
+
+- [Atmosphere](https://github.com/iplantcollaborativeopensource/atmosphere)(2): [Steve Gregory](https://github.com/steve-gregory)
+- [Troposphere](https://github.com/iPlantCollaborativeOpenSource/troposphere): [Andrew Lenards](https://github.com/lenards)
+
+Ancillary projects have a wider set of individuals with write access, these are typically members of the Atmosphere(0) team at CyVerse.

--- a/src/contributing_to_atmosphere/contributing_to_atmosphere.md
+++ b/src/contributing_to_atmosphere/contributing_to_atmosphere.md
@@ -9,7 +9,7 @@ This guide is intended to orient community members who are interested in contrib
 Atmosphere or 'atmo' can refer to several different things:
 
 - [Atmosphere](https://atmo.cyverse.org/application)(0), CyVerse's "cloud computing for scientists" service
-- [Atmosphere](/wiki/display/csmgmt/Atmosphere+Technology+Stack+Overview)(1), **the free, open-source software project** which powers the above service (and is the primary focus of these guides) (TODO fix broken link)
+- Atmosphere(1), **the free, open-source software project** which powers the above service (and is the primary focus of these guides)
 - [Atmosphere](https://github.com/iPlantCollaborativeOpenSource/atmosphere)(2), the API and back-end component of the above software project
 
 For clarity, this page will disambiguate all uses of "Atmosphere".
@@ -49,7 +49,7 @@ Atmosphere(1) is deployed at CyVerse as Atmosphere(0), but also at several other
 
 Familiarize yourself with the following links and use them as a reference.
 
-- [Atmosphere Troubleshooting Orientation](/wiki/display/csmgmt/Atmosphere+Troubleshooting+Orientation) (TODO fix broken link)
+- [Atmosphere Troubleshooting Guide](./troubleshooting_guide.html)
 - [Atmosphere(2) API docs on Apiary](http://docs.atmospherev2.apiary.io/)
 
 ## Key Terms
@@ -59,7 +59,7 @@ You'll hear these a lot on the Atmosphere project:
 - _Instance_: a Virtual Machine (VM) or "cloud computer" running on Atmosphere(0) / OpenStack.
 - _Image:_ a [disk image](https://en.wikipedia.org/wiki/Disk_image) of a Virtual Machine (with some metadata) from which instances are created.
 - _Allocation_: the amount of "CPU time" that a user is allotted, measured in AUs (see below).
-- _Allocation Unit_ _(AU)_: "roughly equivalent to using one CPU-hour, or to using one CPU core for one hour." ([source](https://pods.iplantcollaborative.org/wiki/display/atmman/Requesting+More+Atmosphere+Resources)) (TODO fix broken link)
+- _Allocation Unit_ _(AU)_: "roughly equivalent to using one CPU-hour, or to using one CPU core for one hour." ([source](https://pods.iplantcollaborative.org/wiki/display/atmman/Requesting+More+Atmosphere+Resources))
 - _Modal_: a [modal window](https://en.wikipedia.org/wiki/Modal_window) in a GUI; the Troposphere UI uses these extensively.
 
 ## Technology Stack Overview
@@ -138,7 +138,7 @@ Users can create a secure shell to their VMs directly over the internet, authent
 
 Web Shell gets you a command line session in your browser, launched from the Troposphere UI. Web Shell uses [Gate One](https://liftoff.github.io/GateOne/About/index.html), a web-based terminal emulator. The Gate One server creates an SSH connection to the instance and exposes that shell to the user in a web interface, proxying the SSH traffic. For Atmosphere(0), the GateOne server is known as "bob" / "atmo-proxy".
 
-See [GateOne Background](/wiki/display/csmgmt/GateOne+Background) (TODO migrate the content and fix this link) for detailed design and troubleshooting information.
+See [GateOne Background](/wiki/display/csmgmt/GateOne+Background) (TODO fix this link once the content is migrated) for detailed design and troubleshooting information.
 
 #### Web Desktop
 

--- a/src/index/00_welcome.md
+++ b/src/index/00_welcome.md
@@ -9,6 +9,7 @@ This site hosts documentation for Atmosphere, the free, open-source cloud comput
 - [Install Guide](./install_guide.html)
 - [Connecting a Cloud Provider](./connecting_cloud_provider.html)
 - [Staff Guide](./staff_guide.html)
+- [Troubleshooting Guide](./troubleshooting_guide.html)
 
 ## For Users
 

--- a/src/index/00_welcome.md
+++ b/src/index/00_welcome.md
@@ -1,10 +1,20 @@
 # Atmosphere Guides
 
-This site is intended to provide guides for how Atmosphere should be used. Both by End Users and by Staff and Support.
+This site hosts documentation for Atmosphere, the free, open-source cloud computing project (as distinct from CyVerse's "cloud computing for scientists" service). It is intended for both "site operators" (groups interested in operating/supporting their own Atmosphere deployment), users (very incomplete), and developers who are interested in contributing to the project.
 
 # The Guides
+
+## For Site Operators
+
 - [Install Guide](./install_guide.html)
 - [Connecting a Cloud Provider](./connecting_cloud_provider.html)
 - [Staff Guide](./staff_guide.html)
+
+## For Users
+
 - [User Guide](./user_guide.html)
 - [Imaging Guide](./imaging_guide.html)
+
+## For Developers
+
+- [Contributing to Atmosphere](.contributing_to_atmosphere.html)

--- a/src/index/00_welcome.md
+++ b/src/index/00_welcome.md
@@ -18,4 +18,4 @@ This site hosts documentation for Atmosphere, the free, open-source cloud comput
 
 ## For Developers
 
-- [Contributing to Atmosphere](.contributing_to_atmosphere.html)
+- [Contributing to Atmosphere](./contributing_to_atmosphere.html)

--- a/src/troubleshooting_guide/troubleshooting_guide.md
+++ b/src/troubleshooting_guide/troubleshooting_guide.md
@@ -1,0 +1,139 @@
+# Atmosphere Troubleshooting Guide
+
+Where to look and what to do when something is broken. See also [Taking care of the Atmosphere](/wiki/display/csmgmt/Taking+care+of+the+Atmosphere) (TODO fix link), and [Atmosphere Tips, Troubleshooting, Workarounds, and Solutions](/wiki/display/csmgmt/Atmosphere+Tips%2C+Troubleshooting%2C+Workarounds%2C+and+Solutions) (TODO fix link).
+
+## Common Problems
+
+### My Instance Won't Deploy
+
+Check Atmosphere logs, Kibana, and Celery logs, to determine if the problem is with Atmosphere(2), the OpenStack cloud, or the Ansible code that is run during deployment.
+
+Note that resuming a suspended instance also re-deploys it.
+
+## Troubleshooting Tools
+
+### Launching instances without Troposphere
+
+To launch instances via atmosphere (without the use of a GUI):
+
+```
+#############1 - Setting up the environment ######################
+# Ensure that PYTHONPATH and DJANGO_SETTINGS_MODULE are pointed to atmosphere:
+export PYTHONPATH=/opt/dev/atmosphere:$PYTHONPATH
+export DJANGO_SETTINGS_MODULE=atmosphere.settings
+
+#############2 - Getting the correct arguments ######################
+# Run script with --provider-list to get providers to launch from:
+# ./scripts/launch_instances.py --provider-list
+# ID      Name
+# 1       EUCALYPTUS
+# 2       OPENSTACK
+# 3       EC2_US_EAST
+# 4       Jetstream - Indiana University
+# 5       Jetstream - TACC
+
+# Run script with --provider-id + --size-list and select a size (by ID)
+# ./scripts/launch_instances.py --size-list --provider-id 4
+# ID      Name    CPU     Memory
+# 1       m1.tiny 1       2048
+# 2       m1.small        2       4096
+# 3       m1.medium       6       16384
+# 4       m1.large        10      30720
+# 6       m1.xxlarge      44      122880
+# 8       m1.xlarge       24      61440
+# 30      m1.xlarge.paramtest     24      61440
+
+# Run script with --provider-id + --machine-list and select a machine (by alias)
+# ./scripts/launch_instances.py --skip-deploy --users sgregory --size 3 --provider-id 4 --machine-list
+# Instances Launched: 235 - 30f31162-2a7a-4ac5-be1a-45c7e579a04b (Provider:4:Jetstream - Indiana University - App:Ubuntu 14.04.3 Development GUI by jfischer - 2017-01-02 18:24:00+00:00 Version:Ubuntu 14.04.3 Development GUI - 1.3 - 2016-07-15 21:02:42.359171+00:00)
+# Instances Launched: 156 - 28235434-a4b0-4f27-ad58-e5c3052576da (Provider:4:Jetstream - Indiana University - App:CentOS 6 (6.8) Development GUI by jfischer - 2016-11-04 21:14:02+00:00 Version:CentOS 6 (6.8) Development GUI - 1.5 - 2016-04-01 18:22:33.843209+00:00)
+# Instances Launched: 264 - 01fb694b-a58c-46b2-8744-99e177f6ea34 (Provider:4:Jetstream - Indiana University - App:MAKER 2.31.8 with CCTools by upendra - 2017-01-19 18:08:58+00:00 Version:MAKER 2.31.8 with CCTools - 1.0 - END-DATED)
+# Instances Launched: 118 - 5ad04c2a-1503-4b44-9f5a-ad0abde2a685 (Provider:4:Jetstream - Indiana University - App:I435-I535-B669 Project B by atmoadmin - 2016-11-11 19:41:09+00:00 Version:I435-I535-B669 Project B - 1.0 - 2016-11-11 15:15:06.345665+00:00)
+# Instances Launched: 93 - dbfe6ffa-084f-411d-bde4-676d4ca4da0f (Provider:4:Jetstream - Indiana University - App:CentOS 7 Development by jfischer - END-DATED Version:CentOS 7 Development - 1.1 - END-DATED)
+# Instances Launched: 103 - 1c997f2c-bae9-4b53-9197-2948cd449405 (Provider:4:Jetstream - Indiana University - App:Ubuntu 14.04.3 Trusty Tahr by admin - END-DATED Version:Ubuntu 14.04.3 Trusty Tahr - 1.0 - END-DATED)
+# Instances Launched: 159 - d1126e09-9e87-4f88-914f-fa42ba256c68 (Provider:4:Jetstream - Indiana University - App:BioLinux 8 by jfischer - 2017-01-24 17:25:40+00:00 Version:BioLinux 8 - 1.0 - 2016-03-29 21:38:14.409121+00:00)
+# Instances Launched: 320 - fcc8542f-1b06-4d51-80c9-c8a505bc6eff (Provider:4:Jetstream - Indiana University - App:I535-I435-B669 Project A by luoyu - 2016-10-26 18:08:35+00:00 Version:I535-I435-B669 Project A - 1.0 - 2016-09-21 19:27:05.396602+00:00)
+# Instances Launched: 98 - 3c3db94e-377b-4583-83d7-082d1024d74a (Provider:4:Jetstream - Indiana University - App:Ubuntu 14.04.3 Development by jfischer - END-DATED Version:Ubuntu 14.04.3 Development - 1.1 - 2016-05-24 18:00:30.333275+00:00)
+# Instances Launched: 152 - bd81558e-9ba9-495e-a82c-4fbfc278a5ee (Provider:4:Jetstream - Indiana University - App:Ubuntu 14.04.3 Development GUI by jfischer - 2017-01-02 18:24:00+00:00 Version:Ubuntu 14.04.3 Development GUI - 1.1-stable - 2016-04-13 17:11:44.783177+00:00)
+
+#############3 - Launching the instance ######################
+./scripts/launch_instances.py --users sgregory --size 3 --provider-id 4 --machine-alias 66322719-5bfa-4646-93c6-0132e9a958e5 --name sgregory-testlaunch
+Using Username sgregory.
+Using Provider 4:Jetstream - Indiana University.
+Using Size m1.medium.
+.... Logging output for debug purposes
+....
+Successfully launched Machine 66322719-5bfa-4646-93c6-0132e9a958e5 : 2e90c453-7509-4442-ae28-405b4aaeca10 (Name:sgregory-testlaunch 1, Creator:sgregory, IP:0.0.0.0)
+Launched 1 instances.
+```
+
+### Launching Instances without atmosphere-ansible
+
+Sometimes it is useful to be able to launch instances, add their floating IP, but **skip the ansible portion** of instance deployment. As it turns out, the script above is perfect for this! simply include the flag `--skip-deploy` to **./scripts/launch_instances.py** in addition to the standard arguments and environment setup described in the section above.
+
+```
+#############1 - Setting up the environment ######################
+See above
+#############2 - Getting the correct arguments ######################
+See above
+#############3 - Launching the instance ######################
+./scripts/launch_instances.py --skip-deploy --users sgregory --size 3 --provider-id 4 --machine-alias 66322719-5bfa-4646-93c6-0132e9a958e5 --name sgregory-test-nodeploy
+Using Username sgregory.
+Using Provider 4:Jetstream - Indiana University.
+Using Size m1.medium.
+.... Logging output for debug purposes
+....
+Successfully launched Machine 66322719-5bfa-4646-93c6-0132e9a958e5 : 2e90c453-7509-4442-ae28-405b4aaeca10 (Name:sgregory-test-nodeploy 1, Creator:sgregory, IP:0.0.0.0)
+Launched 1 instances.
+
+## When you decide you would later like to run ansible by hand, via the REPL:
+from service.deploy import instance_deploy
+instance_deploy(...)
+```
+
+### Accessing Atmosphere During Maintenance
+
+There is an "exception" URI to access the UI when Atmosphere is in maintenance mode.
+
+Browse to <a>https://(atmosphere-url)/application_backdoor.</a>
+
+In order to access the backdoor, you will need to be included in [`STAFF_LIST_USERNAMES`](https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/troposphere/settings/local.py.j2#L41-L43) . This is set in the variables.yml (build env) for a deployed environment (dev, beta, prod). Using Jinja2 syntax for referring to YAML data structures, within the build env `variables.yml` file, the list is `TROPO['local.py']['STAFF_LIST_USERNAME']`.
+
+Or:
+
+<pre>TROPO:
+    local.py:
+        STAFF_LIST_USERNAME: ['cmart', 'lenards']</pre>
+
+### Emulating Another Atmosphere(1) User
+
+If you have a staff account in Atmosphere (i.e. you see the "admin" section in Troposphere), you can become ("emulate") another user account. Browse to https://(atmosphere-url)/application/emulate/(username), replacing (atmosphere-url) as appropriate, and (username) with the user you want to emulate. To clear an emulated session, navigate to https://(atmosphere-url)/application/emulate.
+
+### Testing Deployments Against Multiple Distros
+
+See [Images/Accounts to test Ansible](https://pods.iplantcollaborative.org/wiki/display/csmgmt/Ansible+Deployment#AnsibleDeployment-Images/AccountstotestAnsible) (TODO fix link) for a list of images known to work for various distros.
+
+### Capturing Instance Details for Problem Reports
+
+You can easily capture critical information about an instance in order to include it in a problem report. Click on the gravatar (icon), and a string will be printed to your browser's developer tools console in the following format:
+
+```
+<image-name> - <instance-GUID> - <provider> - <ip-address> - <deploy-date-time>
+```
+
+## Logs
+
+### Log Files on Atmosphere server
+
+Atmosphere(1) writes logs to several places:
+
+- Nginx logs in /var/log/nginx
+- uWSGI logs in /var/log/uwsgi/app (atmosphere.log and troposphere.log)
+  - "Internal server error" messages usually point to an error here.
+- Django logs in /opt/dev/atmosphere/logs
+- Celery logs in /var/log/celery
+- atmosphere-ansible run logs in /opt/dev/atmosphere/logs/atmosphere_deploy.log
+
+### Celery Flower
+
+[Flower](https://flower.readthedocs.io/en/latest/) is installed for monitoring Celery tasks (e.g. running Ansible against new instances). Browse to https://(atmosphere-url)/flower. The authentication scheme and credentials are set in clank's variables.yml at deploy time.

--- a/src/troubleshooting_guide/troubleshooting_guide.md
+++ b/src/troubleshooting_guide/troubleshooting_guide.md
@@ -1,6 +1,6 @@
 # Atmosphere Troubleshooting Guide
 
-Where to look and what to do when something is broken. See also [Taking care of the Atmosphere](/wiki/display/csmgmt/Taking+care+of+the+Atmosphere) (TODO fix link), and [Atmosphere Tips, Troubleshooting, Workarounds, and Solutions](/wiki/display/csmgmt/Atmosphere+Tips%2C+Troubleshooting%2C+Workarounds%2C+and+Solutions) (TODO fix link).
+Where to look and what to do when something is broken.
 
 ## Common Problems
 


### PR DESCRIPTION
Migrating documentation for Atmosphere(1) from CyVerse wiki to this public repo/website.

To do after this is merged:
- [x] Fix broken links from internal wiki pages to here
- [x] Link to / incorporate code contribution/style guide once that passes team review (in separate PR)
- [x] Fix a few other things marked todo
- [x] Fix links in https://pods.iplantcollaborative.org/wiki/display/csmgmt/Atmosphere+Release+Deployment+Process