### PR TITLE
Problem: deployment to GitHub Pages is manual

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
 - '2.7'
 install:
-- apt-get install pandoc
+- sudo apt-get install pandoc
 script:
 - make
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: required
 language: python
 python:
 - '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+python:
+- '2.7'
+install:
+- apt-get install pandoc
+script:
+- make
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  local_dir: ./dist
+  name: CyVerse Deploy
+  email: cyverse-deploy@cyverse.org
+  on:
+    branch: master
+env:
+  global:
+    secure: OGsqXnFqsYsQ1socMtEOcQFjmlL5/v9dnPpqAwDzMRjZYFL9Wy71Cnel9oY0NoV6UZxHrtPRj1Syo5p0hrsat01NZBQpGEknnjC2zI/n+ZXRhJO3hlMi8qGxl/Lkg2wha6TSeVmFuR29CjYL5KCUGQA9ssBQ1l3TCxhCorR/FPWPnyWXKUdIMxK9lPYW73+F9nQWOui3bbHZrtpavJSpObbTPRBtZzx95dGgQcPxZyK4lT8DZHz/jXQzFBFwhj9O+VkBsq3hvFruqP9J7KfAjkmNPQP8g6RXtqo/ONnSnoBifYjkkSyuPDu3RHoof1CoA4asl7VNE1CDwjWDlQiQ+AacWkxat43Fe1zQWKDoGVVIJuF3rMIxi0o8ugNRjTwRrAPwYf7wtzmkyYvZ/ZVJv3wjvkllX5MLp2Gmj1xRZl95W19yAUXJ9plXe7NZtlsFlW/mylPQYFLsIV87+fU8871EBvNmtA/PLVknvg6nsQNTPcn/WC8l88b9njLUIOYKDkK8KZJGGwsXXmzFdrZ90maUF6kYbrAmvfeWZHaIkEnCjk88R0hJ+w8cA0/gf5vi16RQ/mK7pxadhnPPtvlWSUNVsggxrEGqHm8HhUoLRsNJJIdGgo8w3fwSEpuW5mwsS1z4JSGte7r3foEIZQWPrA3S59RJoF6oRXWLwhSYPU8=

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,3 @@ Please describe your pull request. If it fixes a bug or resolves a feature reque
 - [ ] Verify that the compiled changes look accurate by viewing the HTML site
 - [ ] If applicable, [Example link to the PR](https://example.test/doc#new_section) to give context to the documentation
 - [ ] Have at least one other contributor review and approve your changes
-
-## Checklist after merging Pull Requests
-- [ ] `make gh-pages-commit` to update static site (see "Pusblishing to GitHub Pages" in README.md)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repo contains multiple guides that are hosted on Github Pages:
 [https://cyverse.github.io/atmosphere-guides](https://cyverse.github.io/atmosphere-guides).
 
+
 ## How to Contribute
 
 ### How to Write Docs
@@ -11,8 +12,10 @@ Guides are written in Markdown. You may want to use a tool to render your Markdo
 Here is another tool to make nice GIFs.
 http://recordit.co/
 
+
 ### How to Publish Docs
 After making changes to the Markdown source, you need to compile them to HTML, then push to the gh-pages branch, from which the static HTML is served.
+
 
 #### Compiling Docs
 First, you must have [pandoc](http://pandoc.org/) installed and in your executable path -- see [Installing Pandoc](http://pandoc.org/installing.html).
@@ -23,8 +26,12 @@ Finally, to compile the docs, run `make` from the root of this repository.
 
 See CONTRIBUTING.md for Pandoc-specific details not covered here.
 
+
 #### Pushing to GitHub Pages
-Static HTML is served on [GitHub Pages](https://pages.github.com/) from the `gh-pages` branch of this repository, which contains only the `dist/` folder of the master branch. After pushing changes to master or merging in a pull request, the gh-pages branch must be updated. A maintainer (someone with write access) can do this by running `make gh-pages-commit` from a local copy of this repository.
+Static HTML is served on [GitHub Pages](https://pages.github.com/) from the `gh-pages` branch of this repository, which contains only the `dist/` folder of the master branch. After pushing changes to master or merging in a pull request, the gh-pages branch will be automatically updated by the Travis CI [deployment provider for GitHub Pages](https://docs.travis-ci.com/user/deployment/pages/). 
+
+Note: if a manual push to `gh-pages` is required, a maintainer (someone with write access) can do this by running `make gh-pages-commit` from a local copy of this repository.
+
 
 ### Notice for CyVerse Documenters
 A lot of Atmosphere documentation lives on the [CyVerse Wiki](https://pods.iplantcollaborative.org/wiki/dashboard.action), some in the [Atmosphere Manual](https://pods.iplantcollaborative.org/wiki/display/atmman/Atmosphere+Manual+Table+of+Contents) and some in private spaces. Going forward, documentation should be maintained as follows:


### PR DESCRIPTION
## Description

Define a [Travis CI](https://docs.travis-ci.com/) build leveraging [GH Pages provider](https://docs.travis-ci.com/user/deployment/pages/).

This work leverages the learning from the definitions of auto-deployment defined within CyVerse-UI.

It adds a Travis CI build definition that will install [`pandoc`](http://pandoc.org/), then generate an HTML representation of the overall "guides". It makes use of an existing Deployment Provider, [pages](https://docs.travis-ci.com/user/deployment/pages/), offered by Travis CI. On success, this will be deployed to GitHub Pages by Travis CI.

The "auto-deploy" is performed by a "service" account, @cyverse-deploy. @cyverse-deploy has *not* be added to the @cyverse org to avoid any leak of permissions. This add only has "write" permission to `cyverse/atmosphere-guides`, by **design**.

A clean environment requires that the `pandoc` package is installed (via `apt-get install`). Then, the repository's default build is run via `make`. The steps to carry out the procedure of 'deployment' require the operations defined in `.travis.yml`.

This work applies what was learned in the [cyverse-ui pull request 40](https://github.com/cyverse/cyverse-ui/pull/40/commits/4f6cd26de021ccd90fbb320be80762a26354377a).

## Checklist before merging Pull Requests
- [x] If providing a step-by-step procedure (e.g. a set of commands to run), *try following your own steps*, ensure they produce the intended result
- [x] Run makefile to compile your changes into the guide (see "Compiling Docs" in README.md)
- [x] Verify that the compiled changes look accurate by viewing the HTML site
- [x] If applicable, [Example link to the PR](https://example.test/doc#new_section) to give context to the documentation
- [x] Have at least one other contributor review and approve your changes

