### PR TITLE
Trying older Travis build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: trusty
+group: deprecated-2017Q3
 sudo: required
 language: python
 python:


### PR DESCRIPTION
## Description

Travis builds were [failing on master](https://travis-ci.org/cyverse/atmosphere-guides/builds/255018342) because of the new Trusty build environment; added `group: deprecated-2017Q3` to try the earlier one and see if builds are fixed.

## Checklist before merging Pull Requests
- [ ] ~If providing a step-by-step procedure (e.g. a set of commands to run), *try following your own steps*, ensure they produce the intended result~
- [ ] ~Run makefile to compile your changes into the guide (see "Compiling Docs" in README.md)~
- [ ] ~Verify that the compiled changes look accurate by viewing the HTML site~
- [ ] ~If applicable, [Example link to the PR](https://example.test/doc#new_section) to give context to the documentation~
- [x] Have at least one other contributor review and approve your changes
