### PR TITLE
Problem: Images in guide content overlap side nav

### DIFF
--- a/dist/themes/cyverse/templates/main.css
+++ b/dist/themes/cyverse/templates/main.css
@@ -25,6 +25,14 @@ hr {
     padding: 0;
 }
 
+/*
+    Makes images in the content body fluid. We may decide this isn't
+    flexible enough but will work until we need more.
+*/
+article img {
+    width: 100%;
+}
+
 audio,
 canvas,
 iframe,
@@ -207,6 +215,7 @@ aside a:hover {
    ============ */
 
     .main article {
+        width: 60%;
         float: left;
     }
 

--- a/dist/themes/jetstream/templates/main.css
+++ b/dist/themes/jetstream/templates/main.css
@@ -25,6 +25,14 @@ hr {
     padding: 0;
 }
 
+/*
+    Makes images in the content body fluid. We may decide this isn't
+    flexible enough but will work until we need more.
+*/
+article img {
+    width: 100%;
+}
+
 audio,
 canvas,
 iframe,
@@ -207,6 +215,7 @@ aside a:hover {
    ============ */
 
     .main article {
+        width: 60%;
         float: left;
     }
 


### PR DESCRIPTION
## Description
Makes all images in the guide content a fluid width so that they don't flow out of the content bounds.

* Undo hot-fix
* Add CSS rule to set all images in guide content to fluid width

## Before
![screen shot 2017-09-14 at 9 05 30 am](https://user-images.githubusercontent.com/7366338/30445970-9fb723bc-993c-11e7-890f-3fd6b45b279c.png)

## After
<img width="1437" alt="screen shot 2017-09-14 at 11 04 25 am" src="https://user-images.githubusercontent.com/7366338/30445976-a42b468a-993c-11e7-8369-d06f62ce9dc6.png">


## Checklist before merging Pull Requests
- [x] Run makefile to compile your changes into the guide (see "Compiling Docs" in README.md)
- [x] Verify that the compiled changes look accurate by viewing the HTML site
- [x] Have at least one other contributor review and approve your changes
