### PR TITLE
Problem: code blocks break layout

### DIFF
--- a/dist/themes/cyverse/templates/main.css
+++ b/dist/themes/cyverse/templates/main.css
@@ -33,6 +33,21 @@ article img {
     width: 100%;
 }
 
+code {
+    line-height: 1.2;
+    display: block;
+    overFlow: scroll;
+    padding: 10px;
+    /* 
+        TODO: normalize.min.css is imported after this file which
+        is wrong. Will look into fixing that and removing this
+        !important rule later
+    */
+    font-size: .9em !important;
+    border-left: solid rgba(0,0,0,.08) 5px;
+    background: rgba(0,0,0,0.03);
+}
+
 audio,
 canvas,
 iframe,

--- a/dist/themes/jetstream/templates/main.css
+++ b/dist/themes/jetstream/templates/main.css
@@ -33,6 +33,21 @@ article img {
     width: 100%;
 }
 
+code {
+    line-height: 1.2;
+    display: block;
+    overFlow: scroll;
+    padding: 10px;
+    /* 
+        TODO: normalize.min.css is imported after this file which
+        is wrong. Will look into fixing that and removing this
+        !important rule later
+    */
+    font-size: .9em !important;
+    border-left: solid rgba(0,0,0,.08) 5px;
+    background: rgba(0,0,0,0.03);
+}
+
 audio,
 canvas,
 iframe,


### PR DESCRIPTION
## Description

The code blocks should hide overflow and allow scrolling to see text wider than bounding area.
Also the font size is a bit large, the line height too loose, and there is not enough differentiation from surrounding text. 

This PR adds CSS to better format code elements.
## Before
<img width="1332" alt="screen shot 2017-09-14 at 12 27 34 pm" src="https://user-images.githubusercontent.com/7366338/30452071-534f3b38-9949-11e7-9559-65594162a084.png">


## After
<img width="828" alt="screen shot 2017-09-14 at 12 32 48 pm" src="https://user-images.githubusercontent.com/7366338/30451885-0b56319c-9949-11e7-9561-bb468cadd8b1.png">



Another problem (not fixed here) is that the code is indented where not intended causing the code to be overly wide and hard to read. This is captured in [this issue](https://github.com/cyverse/atmosphere-guides/issues/29)
 
## Checklist before merging Pull Requests
- [x] Run makefile to compile your changes into the guide (see "Compiling Docs" in README.md)
- [x] Verify that the compiled changes look accurate by viewing the HTML site
- [x] Have at least one other contributor review and approve your changes
