### PR TITLE
Improve user contribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ deploy:
   email: cyverse-deploy@cyverse.org
   on:
     branch: master
+    repo: cyverse/atmosphere-guides
 env:
   global:
   - secure: n7fYxN0Y0ZCDgFiP6bEtz/sYbi65hDH+C9xhxD1OhJHWo9ZZB4hwramZp+ZyTH/St0qb3ZM2MOcN/hvdk/c6krw959xSmP1tldtB4bWErTSCybZQOhwOYs+fmTtjTeT3iQLb0fEuURigC2eBJ6QvjXMM0k5taXLtV9ihuX4dGpQDNeM6swo0jED25nyJOD42BDqlp3t5Vinnp9A9onmPOS1gcKAH9fqMRJMS7BQRwlu80HZLz/9lUKNLwD7lrxlS2VTgRQZEuY9p+3O5fDAxF6y/7okKpKetD4GvixDr47TnpCG/D6NQ35p26bjYcJN76neF7/pf3+x89lYInxZMoYd/l79L2/kQO7Vz8mM1Aqiwh7nrOLC3+x2Fsc3nj+lAcEb0As81IZkrQXXkUa8crsQeKHQp43wTEFi2eIuxtmYqqu4l0GQT/5xMrQehsAbHdl7AIeGbrdIcPIcZOiwblTiH1UIjT6sECNbTo5oI6otlyeLI7HlIgnYHIanS/qXsUvRUC5JB2aOkvu5tq7t6k+EaoHcULF0zBMgrSFahY9ue/nlZgACMzv9YBhb8aUEitJiwf8mEgCox6dHCHj3QDzTSlfS5UnjgDEWwE25px4Y7ymM0gb1e+mfn6cmJ4v5OrBk+Y8Zi5JBEXCTMrTxK2lZV5+qUpn7UpRdTqvR4K/s=

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,6 @@
 
 all: build_html
 
-commit: build_html gh-pages-commit
-
-
-gh-pages-commit:
-	git subtree push --prefix dist origin gh-pages
-
 build_html:
 
 	./scripts/to_html_template.sh index getting_started install_guide staff_guide user_guide imaging_guide connecting_cloud_provider project_contribution_guide code_guidelines atmosphere_troubleshooting_guide openstack_troubleshooting_guide gateone_background

--- a/README.md
+++ b/README.md
@@ -58,10 +58,14 @@ See CONTRIBUTING.md for Pandoc-specific details not covered here.
 
 
 #### Pushing to GitHub Pages
-Static HTML is served on [GitHub Pages](https://pages.github.com/) from the `gh-pages` branch of this repository, which contains only the `dist/` folder of the master branch. After pushing changes to master or merging in a pull request, the gh-pages branch will be automatically updated by the Travis CI [deployment provider for GitHub Pages](https://docs.travis-ci.com/user/deployment/pages/). 
 
-Note: if a manual push to `gh-pages` is required, a maintainer (someone with write access) can do this by running `make gh-pages-commit` from a local copy of this repository.
+Static HTML is served on [GitHub Pages](https://pages.github.com/) from the `gh-pages` branch of this repository, which contains only the `dist/` folder of the master branch. After pushing changes to master or merging in a pull request, the gh-pages branch will be automatically updated by the Travis CI [deployment provider for GitHub Pages](https://docs.travis-ci.com/user/deployment/pages/). This automation only works for cyverse/atmosphere-guides repo at the moment.
 
+If you would like to publish your dist folder to **your fork**'s `gh-pages`:
+```
+# Overwrite your remote's gh-pages
+git push -f <your remote> "$(git subtree split  --prefix dist)":gh-pages
+```
 
 ### Notice for CyVerse Documenters
 A lot of Atmosphere documentation lives on the [CyVerse Wiki](https://pods.iplantcollaborative.org/wiki/dashboard.action), some in the [Atmosphere Manual](https://pods.iplantcollaborative.org/wiki/display/atmman/Atmosphere+Manual+Table+of+Contents) and some in private spaces. Going forward, documentation should be maintained as follows:


### PR DESCRIPTION
## Description

Problems:

- When you fork this repo, travis will fail with your changes, because your travis doesn't have access to the enrypted secret
- The make command to push gh-pages doesn't work for forks. The reason is that forks will clone the gh-pages branch, when they use subtree push against their fork it will fail for two reasons. The first reason is that origin is hard coded (user needs to supply their fork), and secondly travis squashes the history in the gh-pages branch, so subtree push will fail because a fast forward merge is not possible


## Checklist before merging Pull Requests
- [ ] If providing a step-by-step procedure (e.g. a set of commands to run), *try following your own steps*, ensure they produce the intended result
- [ ] Run makefile to compile your changes into the guide (see "Compiling Docs" in README.md)
- [ ] Verify that the compiled changes look accurate by viewing the HTML site
- [ ] If applicable, [Example link to the PR](https://example.test/doc#new_section) to give context to the documentation
- [ ] Have at least one other contributor review and approve your changes
