### PR TITLE
Fix "Getting Started" missing from index page

### DIFF
--- a/dist/atmosphere_troubleshooting_guide.html
+++ b/dist/atmosphere_troubleshooting_guide.html
@@ -8,9 +8,9 @@
         <meta http-equiv="Content-Style-Type" content="text/css" />
         <meta name="generator" content="pandoc" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-                    <title></title>
+                    <title>atmosphere_troubleshooting_guide</title>
         <style type="text/css">code{white-space: pre;}</style>
-                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" type="text/css" />
+                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" />
                     <link rel="icon" href="themes/cyverse/media/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" href="themes/cyverse/media/css/normalize.min.css">
         <link rel="stylesheet" href="themes/cyverse/media/css/main.css">
@@ -55,14 +55,14 @@
                   </aside>
                               <!-- MAIN CONTENT -->
               <article>
-              <h1 id="atmosphere-troubleshooting-guide"><a href="#atmosphere-troubleshooting-guide">Atmosphere Troubleshooting Guide</a></h1>
+              <h1 id="atmosphere-troubleshooting-guide">Atmosphere Troubleshooting Guide</h1>
               <p>Where to look and what to do when something is broken.</p>
-              <h2 id="common-problems"><a href="#common-problems">Common Problems</a></h2>
-              <h3 id="my-instance-wont-deploy"><a href="#my-instance-wont-deploy">My Instance Won’t Deploy</a></h3>
+              <h2 id="common-problems">Common Problems</h2>
+              <h3 id="my-instance-wont-deploy">My Instance Won’t Deploy</h3>
               <p>Check Atmosphere logs, Kibana, and Celery logs, to determine if the problem is with Atmosphere(2), the OpenStack cloud, or the Ansible code that is run during deployment.</p>
               <p>Note that resuming a suspended instance also re-deploys it.</p>
-              <h2 id="troubleshooting-tools"><a href="#troubleshooting-tools">Troubleshooting Tools</a></h2>
-              <h3 id="launching-instances-without-troposphere"><a href="#launching-instances-without-troposphere">Launching instances without Troposphere</a></h3>
+              <h2 id="troubleshooting-tools">Troubleshooting Tools</h2>
+              <h3 id="launching-instances-without-troposphere">Launching instances without Troposphere</h3>
               <p>To launch instances via atmosphere (without the use of a GUI):</p>
               <pre><code>#############1 - Setting up the environment ######################
               # Ensure that PYTHONPATH and DJANGO_SETTINGS_MODULE are pointed to atmosphere:
@@ -112,7 +112,7 @@
               ....
               Successfully launched Machine 66322719-5bfa-4646-93c6-0132e9a958e5 : 2e90c453-7509-4442-ae28-405b4aaeca10 (Name:sgregory-testlaunch 1, Creator:sgregory, IP:0.0.0.0)
               Launched 1 instances.</code></pre>
-              <h3 id="launching-instances-without-atmosphere-ansible"><a href="#launching-instances-without-atmosphere-ansible">Launching Instances without atmosphere-ansible</a></h3>
+              <h3 id="launching-instances-without-atmosphere-ansible">Launching Instances without atmosphere-ansible</h3>
               <p>Sometimes it is useful to be able to launch instances, add their floating IP, but <strong>skip the ansible portion</strong> of instance deployment. As it turns out, the script above is perfect for this! simply include the flag <code>--skip-deploy</code> to <strong>./scripts/launch_instances.py</strong> in addition to the standard arguments and environment setup described in the section above.</p>
               <pre><code>#############1 - Setting up the environment ######################
               See above
@@ -131,7 +131,7 @@
               ## When you decide you would later like to run ansible by hand, via the REPL:
               from service.deploy import instance_deploy
               instance_deploy(...)</code></pre>
-              <h3 id="accessing-atmosphere-during-maintenance"><a href="#accessing-atmosphere-during-maintenance">Accessing Atmosphere During Maintenance</a></h3>
+              <h3 id="accessing-atmosphere-during-maintenance">Accessing Atmosphere During Maintenance</h3>
               <p>There is an “exception” URI to access the UI when Atmosphere is in maintenance mode.</p>
               <p>Browse to <a>https://(atmosphere-url)/application_backdoor.</a></p>
               <p>In order to access the backdoor, you will need to be included in <a href="https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/troposphere/settings/local.py.j2#L41-L43"><code>STAFF_LIST_USERNAMES</code></a> . This is set in the variables.yml (build env) for a deployed environment (dev, beta, prod). Using Jinja2 syntax for referring to YAML data structures, within the build env <code>variables.yml</code> file, the list is <code>TROPO['local.py']['STAFF_LIST_USERNAME']</code>.</p>
@@ -139,26 +139,27 @@
               <pre>TROPO:
                   local.py:
                       STAFF_LIST_USERNAME: ['cmart', 'lenards']</pre>
-              
-              <h3 id="emulating-another-atmosphere1-user"><a href="#emulating-another-atmosphere1-user">Emulating Another Atmosphere(1) User</a></h3>
+              <h3 id="emulating-another-atmosphere1-user">Emulating Another Atmosphere(1) User</h3>
               <p>If you have a staff account in Atmosphere (i.e. you see the “admin” section in Troposphere), you can become (“emulate”) another user account. Browse to https://(atmosphere-url)/application/emulate/(username), replacing (atmosphere-url) as appropriate, and (username) with the user you want to emulate. To clear an emulated session, navigate to https://(atmosphere-url)/application/emulate.</p>
-              <h3 id="testing-deployments-against-multiple-distros"><a href="#testing-deployments-against-multiple-distros">Testing Deployments Against Multiple Distros</a></h3>
+              <h3 id="testing-deployments-against-multiple-distros">Testing Deployments Against Multiple Distros</h3>
               <p>See <a href="https://pods.iplantcollaborative.org/wiki/display/csmgmt/Ansible+Deployment#AnsibleDeployment-Images/AccountstotestAnsible">Images/Accounts to test Ansible</a> (TODO fix link) for a list of images known to work for various distros.</p>
-              <h3 id="capturing-instance-details-for-problem-reports"><a href="#capturing-instance-details-for-problem-reports">Capturing Instance Details for Problem Reports</a></h3>
+              <h3 id="capturing-instance-details-for-problem-reports">Capturing Instance Details for Problem Reports</h3>
               <p>You can easily capture critical information about an instance in order to include it in a problem report. Click on the gravatar (icon), and a string will be printed to your browser’s developer tools console in the following format:</p>
               <pre><code>&lt;image-name&gt; - &lt;instance-GUID&gt; - &lt;provider&gt; - &lt;ip-address&gt; - &lt;deploy-date-time&gt;</code></pre>
-              <h2 id="logs"><a href="#logs">Logs</a></h2>
-              <h3 id="log-files-on-atmosphere-server"><a href="#log-files-on-atmosphere-server">Log Files on Atmosphere server</a></h3>
+              <h2 id="logs">Logs</h2>
+              <h3 id="log-files-on-atmosphere-server">Log Files on Atmosphere server</h3>
               <p>Atmosphere(1) writes logs to several places:</p>
               <ul>
               <li>Nginx logs in /var/log/nginx</li>
-              <li>uWSGI logs in /var/log/uwsgi/app (atmosphere.log and troposphere.log)</li>
+              <li>uWSGI logs in /var/log/uwsgi/app (atmosphere.log and troposphere.log)
+              <ul>
               <li>“Internal server error” messages usually point to an error here.</li>
+              </ul></li>
               <li>Django logs in /opt/dev/atmosphere/logs</li>
               <li>Celery logs in /var/log/celery</li>
               <li>atmosphere-ansible run logs in /opt/dev/atmosphere/logs/atmosphere_deploy.log</li>
               </ul>
-              <h3 id="celery-flower"><a href="#celery-flower">Celery Flower</a></h3>
+              <h3 id="celery-flower">Celery Flower</h3>
               <p><a href="https://flower.readthedocs.io/en/latest/">Flower</a> is installed for monitoring Celery tasks (e.g. running Ansible against new instances). Browse to https://(atmosphere-url)/flower. The authentication scheme and credentials are set in clank’s variables.yml at deploy time.</p>
               </article>
             </div> <!-- #main -->

--- a/dist/code_guidelines.html
+++ b/dist/code_guidelines.html
@@ -8,28 +8,74 @@
         <meta http-equiv="Content-Style-Type" content="text/css" />
         <meta name="generator" content="pandoc" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-                    <title></title>
+                    <title>code_guidelines</title>
         <style type="text/css">code{white-space: pre;}</style>
                     <style type="text/css">
-      table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode {
-        margin: 0; padding: 0; vertical-align: baseline; border: none; }
-      table.sourceCode { width: 100%; line-height: 100%; }
-      td.lineNumbers { text-align: right; padding-right: 4px; padding-left: 4px; color: #aaaaaa; border-right: 1px solid #aaaaaa; }
-      td.sourceCode { padding-left: 5px; }
-      code > span.kw { color: #007020; font-weight: bold; }
-      code > span.dt { color: #902000; }
-      code > span.dv { color: #40a070; }
-      code > span.bn { color: #40a070; }
-      code > span.fl { color: #40a070; }
-      code > span.ch { color: #4070a0; }
-      code > span.st { color: #4070a0; }
-      code > span.co { color: #60a0b0; font-style: italic; }
-      code > span.ot { color: #007020; }
-      code > span.al { color: #ff0000; font-weight: bold; }
-      code > span.fu { color: #06287e; }
-      code > span.er { color: #ff0000; font-weight: bold; }
+      a.sourceLine { display: inline-block; line-height: 1.25; }
+      a.sourceLine { pointer-events: none; color: inherit; text-decoration: inherit; }
+      a.sourceLine:empty { height: 1.2em; position: absolute; }
+      .sourceCode { overflow: visible; }
+      code.sourceCode { white-space: pre; position: relative; }
+      div.sourceCode { margin: 1em 0; }
+      pre.sourceCode { margin: 0; }
+      @media screen {
+      div.sourceCode { overflow: auto; }
+      }
+      @media print {
+      code.sourceCode { white-space: pre-wrap; }
+      a.sourceLine { text-indent: -1em; padding-left: 1em; }
+      }
+      pre.numberSource a.sourceLine
+        { position: relative; }
+      pre.numberSource a.sourceLine:empty
+        { position: absolute; }
+      pre.numberSource a.sourceLine::before
+        { content: attr(data-line-number);
+          position: absolute; left: -5em; text-align: right; vertical-align: baseline;
+          border: none; pointer-events: all;
+          -webkit-touch-callout: none; -webkit-user-select: none;
+          -khtml-user-select: none; -moz-user-select: none;
+          -ms-user-select: none; user-select: none;
+          padding: 0 4px; width: 4em;
+          color: #aaaaaa;
+        }
+      pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+      div.sourceCode
+        {  }
+      @media screen {
+      a.sourceLine::before { text-decoration: underline; }
+      }
+      code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+      code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+      code span.at { color: #7d9029; } /* Attribute */
+      code span.bn { color: #40a070; } /* BaseN */
+      code span.bu { } /* BuiltIn */
+      code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+      code span.ch { color: #4070a0; } /* Char */
+      code span.cn { color: #880000; } /* Constant */
+      code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+      code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+      code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+      code span.dt { color: #902000; } /* DataType */
+      code span.dv { color: #40a070; } /* DecVal */
+      code span.er { color: #ff0000; font-weight: bold; } /* Error */
+      code span.ex { } /* Extension */
+      code span.fl { color: #40a070; } /* Float */
+      code span.fu { color: #06287e; } /* Function */
+      code span.im { } /* Import */
+      code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+      code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+      code span.op { color: #666666; } /* Operator */
+      code span.ot { color: #007020; } /* Other */
+      code span.pp { color: #bc7a00; } /* Preprocessor */
+      code span.sc { color: #4070a0; } /* SpecialChar */
+      code span.ss { color: #bb6688; } /* SpecialString */
+      code span.st { color: #4070a0; } /* String */
+      code span.va { color: #19177c; } /* Variable */
+      code span.vs { color: #4070a0; } /* VerbatimString */
+      code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
         </style>
-                    <link rel="stylesheet" href="./themes/cyverse/templates/main.css" type="text/css" />
+                    <link rel="stylesheet" href="./themes/cyverse/templates/main.css" />
                     <link rel="icon" href="themes/cyverse/media/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" href="themes/cyverse/media/css/normalize.min.css">
         <link rel="stylesheet" href="themes/cyverse/media/css/main.css">
@@ -95,14 +141,14 @@
                   </aside>
                               <!-- MAIN CONTENT -->
               <article>
-              <h1 id="atmosphere-code-guidelines"><a href="#atmosphere-code-guidelines">Atmosphere Code Guidelines</a></h1>
+              <h1 id="atmosphere-code-guidelines">Atmosphere Code Guidelines</h1>
               <p>These guidelines will improve the consistency and comprehensibility of our code. Contributions to “the Atmosphere projects” (atmosphere, troposphere, atmosphere-ansible, clank, etc) will be checked for adherence.</p>
               <ul>
               <li><a href="https://late.am/post/2016/04/28/delete-your-dead-code.html">Delete your dead code</a>. If you know that code is not run, don’t comment it out, instead remove it completely. Old code remains in version control and we can dig into the past if needed.</li>
               </ul>
-              <h2 id="ansible-style-guidelines"><a href="#ansible-style-guidelines">Ansible Style Guidelines</a></h2>
+              <h2 id="ansible-style-guidelines">Ansible Style Guidelines</h2>
               <p>These apply to repos such as clank and atmosphere-ansible (collectively, “the Ansible projects”). Some are borrowed from <a href="https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions">Open edX Operations</a> and <a href="http://docs.openstack.org/developer/openstack-ansible/developer-docs/contribute.html">OpenStack-Ansible</a>.</p>
-              <h3 id="yaml-files-and-formatting"><a href="#yaml-files-and-formatting">YAML Files and Formatting</a></h3>
+              <h3 id="yaml-files-and-formatting">YAML Files and Formatting</h3>
               <p>YAML files should:</p>
               <ul>
               <li>Have a name ending in <code>.yml</code></li>
@@ -124,7 +170,7 @@
                       python a very long command --with=very --long-options=foo
                       --and-even=more_options --like-these
               </code></pre>
-              <h3 id="variables"><a href="#variables">Variables</a></h3>
+              <h3 id="variables">Variables</h3>
               <ul>
               <li>Use spaces between double-braces and variable names: <code>{{ var }}</code> instead of <code>{{var}}</code></li>
               <li>For boolean variables, use un-quoted <code>true</code> and <code>false</code></li>
@@ -134,7 +180,7 @@
               <ul>
               <li>For variables that have some default and are optionally overridden by a consumer/deployer: define the variable’s default value in the role <code>defaults/</code> instead of using the <code>| default()</code> jinja2 filter. This keeps configuration separate from code.</li>
               </ul>
-              <h4 id="distro-specific-variables"><a href="#distro-specific-variables">Distro-Specific Variables</a></h4>
+              <h4 id="distro-specific-variables">Distro-Specific Variables</h4>
               <p>Many roles must take <em>differently-configured</em> actions to effect the same result, depending on the target’s operating system. Accomplish this configuration by defining your variables in files like so:</p>
               <pre><code>vars/
               ├── CentOS-5.yml
@@ -150,21 +196,22 @@
                   - &quot;{{ ansible_distribution }}.yml&quot;</code></pre>
               <p>Matching is most-specific to least-specific, so with the above example, a role targeting an Ubuntu 16.04 system would include the variables defined in Ubuntu-16.yml, while a role targeting Ubuntu 14.04 would include the variables defined in Ubuntu.yml. Also, only one file will match and there is no concept of inheritance (so usually, the same variables should be defined in each file).</p>
               <p>Role-specific variables that do not vary per-distro can still be defined in <code>vars/main.yml</code> or <code>defaults/main.yml</code>.</p>
-              <h3 id="tasks"><a href="#tasks">Tasks</a></h3>
+              <h3 id="tasks">Tasks</h3>
               <p>Name your tasks to reflect the completed action in the past tense: <code>denyhosts stopped and disabled</code> rather than <code>stop and disable denyhosts</code>. This reinforces the goal of defining a series of idempotent steps to either reach or confirm a desired end state.</p>
-              <h3 id="conditional-logic"><a href="#conditional-logic">Conditional Logic</a></h3>
+              <h3 id="conditional-logic">Conditional Logic</h3>
               <ul>
-              <li>To conditionally include or exclude a role, use the following syntax in a playbook:</li>
+              <li><p>To conditionally include or exclude a role, use the following syntax in a playbook:</p>
+              <pre><code>  roles:
+                - { role: ldap, when: CONFIGURE_LDAP == true }</code></pre>
+              <p>Avoid applying the same tag to every task in a role and expecting a user to skip a role with <code>--skip-tags</code>.</p></li>
               </ul>
-              <p><code>roles:     - { role: ldap, when: CONFIGURE_LDAP == true }</code></p>
-              <p>Avoid applying the same tag to every task in a role and expecting a user to skip a role with <code>--skip-tags</code>.</p>
-              <h3 id="modules"><a href="#modules">Modules</a></h3>
+              <h3 id="modules">Modules</h3>
               <ul>
               <li>Use <code>command</code> rather than <code>shell</code> unless shell is explicitly required (<a href="http://docs.ansible.com/ansible/shell_module.html#notes">source 0</a> <a href="https://blog.confirm.ch/ansible-modules-shell-vs-command/">source 1</a>).</li>
               </ul>
-              <h3 id="files-and-installation-packages"><a href="#files-and-installation-packages">Files and Installation Packages</a></h3>
+              <h3 id="files-and-installation-packages">Files and Installation Packages</h3>
               <p>Avoid storing large binary files or installation packages in Ansible projects / version control. Instead, host it externally (e.g. CyVerse’s S3 account) and download from there, or download from the publisher.</p>
-              <h3 id="possible-ansible-guidelines---things-to-discuss"><a href="#possible-ansible-guidelines---things-to-discuss">Possible Ansible Guidelines - Things to Discuss</a></h3>
+              <h3 id="possible-ansible-guidelines---things-to-discuss">Possible Ansible Guidelines - Things to Discuss</h3>
               <ul>
               <li><a href="https://github.com/whitecloud/ansible-styleguide#quotes">Quote all strings and prefer single quotes over double quotes</a>? This makes clear what is a string and what refers to a variable</li>
               <li>Define a <a href="https://github.com/whitecloud/ansible-styleguide#task-declaration">general order for a task declaration</a>?</li>
@@ -174,36 +221,36 @@
               <li>Prefix task names with the role name, to ease human parsing of log output?</li>
               <li>Separate words in role names with dashes (<code>my-role</code>)?</li>
               </ul>
-              <h2 id="ansible-galaxy-roles"><a href="#ansible-galaxy-roles">Ansible Galaxy Roles</a></h2>
+              <h2 id="ansible-galaxy-roles">Ansible Galaxy Roles</h2>
               <p>The Ansible projects will use similar code to perform very similar tasks, so there is an effort to structure our code into modular, re-usable roles. These roles are generally hosted in the <a href="https://github.com/cyverse-ansible">CyVerse-Ansible</a> organization and consumed via <a href="https://galaxy.ansible.com/">Ansible Galaxy</a>. This will centralize the development/maintenance effort and provide easy consumption by any interested groups. New Ansible contributors are encouraged to read <a href="https://galaxy.ansible.com/intro">Ansible Galaxy Intro</a>.</p>
-              <h4 id="identifying-and-working-with-galaxy-roles"><a href="#identifying-and-working-with-galaxy-roles">Identifying and Working With Galaxy Roles</a></h4>
+              <h4 id="identifying-and-working-with-galaxy-roles">Identifying and Working With Galaxy Roles</h4>
               <p>The Ansible projects include a mix of roles installed from Galaxy and roles defined locally. The following clues should indicate that a given role was installed from Galaxy.</p>
               <ul>
               <li>The role is defined in the project’s <code>requirements.yml</code></li>
               <li>The role contains <code>meta/galaxy_install_info</code> and <code>meta/main.yml</code></li>
               </ul>
               <p>There is a clear concept of “upstream” (roles) and “downstream” (projects that consume them), so generally we should <em>avoid making persistent changes</em> to a role which has been installed from Galaxy <em>inside a repository that consumes it</em>. Such changes will 1. not propagate back upstream to the role repository, and 2. be overwritten the next time the role is updated from Galaxy. Instead, make your changes in the upstream Ansible role (see below), re-import it, and install the new version in the consuming repository.</p>
-              <h4 id="installing-consuming-galaxy-roles-in-another-project"><a href="#installing-consuming-galaxy-roles-in-another-project">Installing (Consuming) Galaxy Roles in Another Project</a></h4>
+              <h4 id="installing-consuming-galaxy-roles-in-another-project">Installing (Consuming) Galaxy Roles in Another Project</h4>
               <p>The Ansible projects use a <code>requirements.yml</code> file to define the Galaxy roles we are consuming. Install new roles and update existing roles in a repo by running <code>ansible-galaxy install -f -r requirements.yml -p roles/</code> from the <code>ansible</code> folder. Then, the desired roles will be copied into your project, and you can call them from Playbooks like any other role.</p>
-              <h4 id="importing-contributing-a-role-to-galaxy"><a href="#importing-contributing-a-role-to-galaxy">Importing (Contributing) a Role to Galaxy</a></h4>
+              <h4 id="importing-contributing-a-role-to-galaxy">Importing (Contributing) a Role to Galaxy</h4>
               <p>Follow the instructions in <a href="https://github.com/CyVerse-Ansible/ansible-role-template">this template</a> to publish an Ansible role to Galaxy and set up automated testing with Travis CI; then you can install the role into other projects.</p>
               <p>When you’re ready to add your project to the CyVerse-Ansible organiztion contact Chris Martin for an invite.</p>
               <p><strong>Note for maintainers:</strong> It is suggested that roles in Cyverse-Ansible be versioned with tags. Be cognizant to push tags when the project changes, and please follow the <a href="https://semver.org/">SemVer</a> protocol.</p>
-              <h2 id="security-guidelines"><a href="#security-guidelines">Security Guidelines</a></h2>
+              <h2 id="security-guidelines">Security Guidelines</h2>
               <p>Do not store anything secret or sensitive (e.g. passphrases, SSH private keys, license keys) in public version control. Environment-specific secrets can be encrypted with Ansible Vault and stored in private version control.</p>
               <p>When using <code>ansible-vault</code>, consider the following suggestions: * Use one password per repository * Vaulted file names should be pre-fixed or suffixed with <em>“vault”</em> - <code>vault-sample-file-name.yml</code> - <code>sample-file-name-vault.yml</code></p>
               <p>Any REST API calls that handle privileged/sensitive information (or access to private resources) should use HTTPS endpoints. Also, any downloaded code that will be executed in a trusted context (e.g. scripts and installation packages) should be obtained in a way that verifies the other party’s authenticity and prevents man-in-the-middle attacks from changing the contents. In practical terms, use HTTPS, or APT packages signed with a GPG key. Avoid disabling SSL certificate verification for any of the above.</p>
               <p>Avoid disabling SSH host key checking. When possible, learn a server’s SSH host key out-of-band and verify it on first connection.</p>
-              <h2 id="contribution-guide-contribution-guide"><a href="#contribution-guide-contribution-guide">Contribution Guide Contribution Guide</a></h2>
+              <h2 id="contribution-guide-contribution-guide">Contribution Guide Contribution Guide</h2>
               <p>If you ask someone not to do something, offer a reasonable alternative approach. Otherwise, they may ignore your advice for the sake of pragmatism.</p>
-              <h2 id="further-reading"><a href="#further-reading">Further Reading</a></h2>
+              <h2 id="further-reading">Further Reading</h2>
               <ul>
               <li><a href="http://wiki.c2.com/?CodeSmell">Code Smells</a></li>
               </ul>
-              <h1 id="python-style-guidelines"><a href="#python-style-guidelines">Python Style Guidelines</a></h1>
+              <h1 id="python-style-guidelines">Python Style Guidelines</h1>
               <p>This Python style guide is largely copied from <a href="http://cosdev.readthedocs.io/en/latest/style_guides/python.html">Center for Open Science</a></p>
               <p>Follow <a href="http://www.python.org/dev/peps/pep-0008/">PEP8</a>, when sensible.</p>
-              <h2 id="naming"><a href="#naming">Naming</a></h2>
+              <h2 id="naming">Naming</h2>
               <ul>
               <li>Variables, functions, methods, packages, modules
               <ul>
@@ -226,14 +273,14 @@
               <li><code>ALL_CAPS_WITH_UNDERSCORES</code></li>
               </ul></li>
               </ul>
-              <h3 id="general-naming-guidelines"><a href="#general-naming-guidelines">General Naming Guidelines</a></h3>
+              <h3 id="general-naming-guidelines">General Naming Guidelines</h3>
               <p>Use singlequotes for strings, unless doing so requires lots of escaping.</p>
               <p>Avoid one-letter variables (esp. <code>l</code>, <code>O</code>, <code>I</code>).</p>
               <p><em>Exception</em>: In very short blocks, when the meaning is clearly visible from the immediate context</p>
-              <pre class="sourceCode"><code>for e in elements:
+              <pre class="sourcecode"><code>for e in elements:
                   e.mutate()</code></pre>
               <p>Avoid redundant labeling.</p>
-              <pre class="sourceCode"><code># Yes
+              <pre class="sourcecode"><code># Yes
               import audio
               
               core = audio.Core()
@@ -245,7 +292,7 @@
               core = audio.AudioCore()
               controller = audio.AudioController()</code></pre>
               <p>Prefer “reverse notation”.</p>
-              <pre class="sourceCode"><code># Yes
+              <pre class="sourcecode"><code># Yes
               elements = ...
               elements_active = ...
               elements_defunct = ...
@@ -255,16 +302,16 @@
               active_elements = ...
               defunct_elements ...</code></pre>
               <p>Avoid getter and setter methods.</p>
-              <pre class="sourceCode"><code># Yes
+              <pre class="sourcecode"><code># Yes
               person.age = 42
               
               # No
               person.set_age(42)</code></pre>
-              <h2 id="indentation"><a href="#indentation">Indentation</a></h2>
+              <h2 id="indentation">Indentation</h2>
               <p>Use 4 spaces–never tabs. You may need to change the settings in your text editor of choice.</p>
-              <h2 id="imports"><a href="#imports">Imports</a></h2>
+              <h2 id="imports">Imports</h2>
               <p>Import entire modules instead of individual symbols within a module. For example, for a top-level module canteen that has a file canteen/sessions.py,</p>
-              <pre class="sourceCode"><code># Yes
+              <pre class="sourcecode"><code># Yes
               
               import canteen
               import canteen.sessions
@@ -276,19 +323,19 @@
               <p><em>Exception</em>: For third-party code where documentation explicitly says to import individual symbols.</p>
               <p><em>Rationale</em>: Avoids circular imports. See <a href="https://sites.google.com/a/khanacademy.org/forge/for-developers/styleguide/python#TOC-Imports">here</a>.</p>
               <p>Put all imports at the top of the page with three sections, each separated by a blank line, in this order:</p>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li>System imports</li>
               <li>Third-party imports</li>
               <li>Local source tree imports</li>
               </ol>
               <p><em>Rationale</em>: Makes it clear where each module is coming from.</p>
               <p>If you have intentionally have an unused import that exists only to make imports less verbose, be explicit about it. This will make sure that someone doesn’t accidentally remove the import (not to mention that it keeps linters happy)</p>
-              <pre class="sourceCode"><code>from my.very.distant.module import Frob
+              <pre class="sourcecode"><code>from my.very.distant.module import Frob
               
               Frob = Frob</code></pre>
-              <h2 id="string-formatting"><a href="#string-formatting">String formatting</a></h2>
+              <h2 id="string-formatting">String formatting</h2>
               <p>Prefer <code>str.format</code> to “%-style” formatting.</p>
-              <pre class="sourceCode"><code># Yes
+              <pre class="sourcecode"><code># Yes
               &#39;Hello {}&#39;.format(&#39;World&#39;)
                # OR
               &#39;Hello {name}&#39;.format(name=&#39;World&#39;)
@@ -296,14 +343,14 @@
               # No
               
               &#39;Hello %s&#39; % (&#39;World&#39;, )</code></pre>
-              <h2 id="print-statements"><a href="#print-statements">Print statements</a></h2>
+              <h2 id="print-statements">Print statements</h2>
               <p>Use the <code>print()</code> function rather than the <code>print</code> keyword (even if you’re using Python 2).</p>
-              <pre class="sourceCode"><code># Yes
+              <pre class="sourcecode"><code># Yes
               print(&#39;Hello {}&#39;.format(name))
               
               # No
               print &#39;Hello %s &#39; % name</code></pre>
-              <h2 id="documentation"><a href="#documentation">Documentation</a></h2>
+              <h2 id="documentation">Documentation</h2>
               <p>Follow <a href="http://www.python.org/dev/peps/pep-0257/">PEP257</a>’s docstring guidelines. <a href="http://docutils.sourceforge.net/docs/user/rst/quickref.html">reStructured Text</a> and <a href="http://sphinx-doc.org/">Sphinx</a> can help to enforce these standards.</p>
               <p>All functions should have a docstring - for very simple functions, one line may be enough:</p>
               <pre><code>&quot;&quot;&quot;Return the pathname of ``foo``.&quot;&quot;&quot;</code></pre>
@@ -315,7 +362,6 @@
               <li>Return type and semantics, unless <code>None</code> is returned</li>
               </ul>
               <!-- -->
-              
               <pre><code>&quot;&quot;&quot;Train a model to classify Foos and Bars.
               
               Usage::
@@ -332,7 +378,7 @@
               <li>Use action words (“Return”) rather than descriptions (“Returns”).</li>
               <li>Document <code>__init__</code> methods in the docstring for the class.</li>
               </ul>
-              <pre class="sourceCode"><code>class Person(object):
+              <pre class="sourcecode"><code>class Person(object):
                   &quot;&quot;&quot;A simple representation of a human being.
               
                   :param name: A string, the person&#39;s name.
@@ -341,9 +387,9 @@
                   def __init__(self, name, age):
                       self.name = name
                       self.age = age</code></pre>
-              <h2 id="on-comments"><a href="#on-comments">On Comments</a></h2>
+              <h2 id="on-comments">On Comments</h2>
               <p>Use them sparingly. Prefer code readability to writing a lot of comments. Often, small methods and functions are more effective than comments.</p>
-              <pre class="sourceCode"><code># Yes
+              <pre class="sourcecode"><code># Yes
               def is_stop_sign(sign):
                   return sign.color == &#39;red&#39; and sign.sides == 8
               
@@ -355,37 +401,37 @@
               if sign.color == &#39;red&#39; and sign.sides == 8:
                   stop()</code></pre>
               <p>When you do write comments, use them to explain <em>why</em> a piece code was used, not <em>what</em> it does.</p>
-              <h3 id="method-overrides"><a href="#method-overrides">Method Overrides</a></h3>
+              <h3 id="method-overrides">Method Overrides</h3>
               <p>One useful place for comments are method overrides.</p>
-              <pre class="sourceCode"><code>class UserDetail(generics.RetrieveUpdateAPIView, UserMixin):
+              <pre class="sourcecode"><code>class UserDetail(generics.RetrieveUpdateAPIView, UserMixin):
               
                   # overrides RetrieveUpdateAPIView
                   def get_serializer_context(self):
                       return {&#39;request&#39;: self.request}</code></pre>
-              <h2 id="calling-superclasses-methods"><a href="#calling-superclasses-methods">Calling Superclasses’ Methods</a></h2>
+              <h2 id="calling-superclasses-methods">Calling Superclasses’ Methods</h2>
               <p>Use super when there is only one superclass.</p>
-              <pre class="sourceCode"><code>class Employee(Person):
+              <pre class="sourcecode"><code>class Employee(Person):
               
                   def __init__(self, name):
                       super(Employee, self).__init__(name)
                       # or super().__init__(name) in Python 3
                       # ...</code></pre>
               <p>Call the method directly when there are multiple superclasses.</p>
-              <pre class="sourceCode"><code>class DevOps(Developer, Operations):
+              <pre class="sourcecode"><code>class DevOps(Developer, Operations):
               
                   def __init__(self):
                       Developer.__init__(self)
                       # ...</code></pre>
-              <h2 id="line-lengths"><a href="#line-lengths">Line lengths</a></h2>
+              <h2 id="line-lengths">Line lengths</h2>
               <p>Don’t stress over it. 80-100 characters is fine.</p>
               <p>Use parentheses for line continuations.</p>
-              <pre class="sourceCode"><code>wiki = (
+              <pre class="sourcecode"><code>wiki = (
                   &quot;The Colt Python is a .357 Magnum caliber revolver formerly manufactured &quot;
                   &quot;by Colt&#39;s Manufacturing Company of Hartford, Connecticut. It is sometimes &quot;
                   &#39;referred to as a &quot;Combat Magnum&quot;. It was first introduced in 1955, the &#39;
                   &quot;same year as Smith &amp; Wesson&#39;s M29 .44 Magnum.&quot;
               )</code></pre>
-              <h2 id="recommended-syntax-checkers"><a href="#recommended-syntax-checkers">Recommended Syntax Checkers</a></h2>
+              <h2 id="recommended-syntax-checkers">Recommended Syntax Checkers</h2>
               <p>We recommend using a syntax checker to help you find errors quickly and easily format your code to abide by the guidelines above. <a href="http://flake8.readthedocs.org/en/latest/">Flake8</a> is our recommended checker for Python. It will check for both syntax and style errors and is easily configurable. It can be installed with pip: :</p>
               <pre><code>$ pip install flake8</code></pre>
               <p>Once installed, you can run a check with: :</p>
@@ -400,12 +446,12 @@
               <li><a href="https://sublime.wbond.net/packages/SublimeLinter">Sublime Linter</a> with <a href="https://sublime.wbond.net/packages/SublimeLinter-flake8">SublimeLinter-flake8</a> (must install both)</li>
               </ul>
               <p>It is recommended that you use the git <code>pre-commit</code> hook to ensure your code is compliant with our style guide.</p>
-              <pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">ln</span> -s <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/contrib/pre-commit.hook <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/.git/hooks/pre-commit</code></pre>
+              <div class="sourceCode" id="cb26"><pre class="sourceCode bash"><code class="sourceCode bash"><a class="sourceLine" id="cb26-1" data-line-number="1"><span class="fu">ln</span> -s <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>/contrib/pre-commit.hook <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>/.git/hooks/pre-commit</a></code></pre></div>
               <p>To automate running tests before a push use the git <code>pre-push</code> hook to ensure your code passes all the tests.</p>
-              <pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">ln</span> -s <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/contrib/pre-push.hook <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>.git/hooks/pre-push</code></pre>
+              <div class="sourceCode" id="cb27"><pre class="sourceCode bash"><code class="sourceCode bash"><a class="sourceLine" id="cb27-1" data-line-number="1"><span class="fu">ln</span> -s <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>/contrib/pre-push.hook <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>.git/hooks/pre-push</a></code></pre></div>
               <p>When master is pulled, it’s helpful to know if a <code>pip install</code> or a <code>manage.py migrate</code> is necessary. To get other helpful warnings:</p>
-              <pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">ln</span> -s <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/contrib/post-merge.hook <span class="ot">$(</span><span class="kw">pwd</span><span class="ot">)</span>/.git/hooks/post-merge</code></pre>
-              <h2 id="credits"><a href="#credits">Credits</a></h2>
+              <div class="sourceCode" id="cb28"><pre class="sourceCode bash"><code class="sourceCode bash"><a class="sourceLine" id="cb28-1" data-line-number="1"><span class="fu">ln</span> -s <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>/contrib/post-merge.hook <span class="va">$(</span><span class="bu">pwd</span><span class="va">)</span>/.git/hooks/post-merge</a></code></pre></div>
+              <h2 id="credits">Credits</h2>
               <ul>
               <li><a href="http://cosdev.readthedocs.io/en/latest/style_guides/python.html">Center for Open Science</a></li>
               <li><a href="http://www.python.org/dev/peps/pep-0008/">PEP8</a> (Style Guide for Python)</li>

--- a/dist/connecting_cloud_provider.html
+++ b/dist/connecting_cloud_provider.html
@@ -8,9 +8,9 @@
         <meta http-equiv="Content-Style-Type" content="text/css" />
         <meta name="generator" content="pandoc" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-                    <title></title>
+                    <title>connecting_cloud_provider</title>
         <style type="text/css">code{white-space: pre;}</style>
-                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" type="text/css" />
+                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" />
                     <link rel="icon" href="themes/cyverse/media/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" href="themes/cyverse/media/css/normalize.min.css">
         <link rel="stylesheet" href="themes/cyverse/media/css/main.css">
@@ -61,13 +61,13 @@
                   </aside>
                               <!-- MAIN CONTENT -->
               <article>
-              <h1 id="connecting-a-cloud-provider-to-atmosphere"><a href="#connecting-a-cloud-provider-to-atmosphere">Connecting a Cloud Provider to Atmosphere</a></h1>
-              <h2 id="overview"><a href="#overview">Overview</a></h2>
+              <h1 id="connecting-a-cloud-provider-to-atmosphere">Connecting a Cloud Provider to Atmosphere</h1>
+              <h2 id="overview">Overview</h2>
               <p>This guide will help you connect Atmosphere to an OpenStack cloud. Atmosphere connects to OpenStack APIs using both LibCloud and the OpenStack client tools.</p>
               <p>This is a work in progress, see Chris Martin or Steve Gregory with questions.</p>
-              <h3 id="production-or-testing"><a href="#production-or-testing">Production or Testing?</a></h3>
+              <h3 id="production-or-testing">Production or Testing?</h3>
               <p>This guide is oriented toward building a production-quality OpenStack + Atmosphere deployment. Many of the steps are unnecessary if you are just creating a test environment. Steps which are absolutely required are marked with a * , other steps are merely recommendations for production use.</p>
-              <h2 id="prerequisites"><a href="#prerequisites">Prerequisites</a></h2>
+              <h2 id="prerequisites">Prerequisites</h2>
               <ul>
               <li>Administrative access to an Atmosphere(1) deployment *</li>
               <li>Administrative access to an OpenStack deployment configured with: *
@@ -75,21 +75,23 @@
               <li>At least one image, size, network, and router (<a href="https://github.com/cyverse/openstack-ansible-host-prep/blob/master/docs/post-deployment.md">example directions</a>)</li>
               <li>An external network with floating IP addresses available to instances, which are routable at least from your Atmosphere server *</li>
               </ul></li>
-              <li>DNS hostname to use for HTTPS connections to your OpenStack APIs, and a client-trusted TLS certificate for this hostname If you need a certificate, <a href="https://letsencrypt.org/">Let’s Encrypt</a> is your friend</li>
+              <li>DNS hostname to use for HTTPS connections to your OpenStack APIs, and a client-trusted TLS certificate for this hostname If you need a certificate, <a href="https://letsencrypt.org/">Let’s Encrypt</a> is your friend
+              <ul>
               <li>Control of a DNS zone that you want to use for instance public IPs (probably optional, can be same zone as above)</li>
+              </ul></li>
               </ul>
               <p>Before attempting to connect Atmosphere to your OpenStack cloud, exercise the cloud to confirm basic functionality. Using the Horizon dashboard or OpenStack APIs, verify you can launch an instance, assign a floating IP address, SSH to your instance, create and attach Cinder volumes, and so forth.</p>
-              <h3 id="dns-for-instance-ip-space"><a href="#dns-for-instance-ip-space">DNS for Instance IP Space</a></h3>
+              <h3 id="dns-for-instance-ip-space">DNS for Instance IP Space</h3>
               <p>This step is probably optional.</p>
               <p>Atmosphere will use a range of DNS names corresponding to your floating IP addresses; the naming convention is configurable when you add the cloud provider below. So, assign hostnames for each of the possible floating IPs in a DNS zone that you control, e.g. vm#.myawesomecloud.org. For example, if your range of available public IPs is 1.2.3.2-62, then create records that resolve vm40.myawesomecloud.org to 1.2.3.40, and so forth throughout the range.</p>
-              <h3 id="tls-certificate-for-openstack-api-endpoints"><a href="#tls-certificate-for-openstack-api-endpoints">TLS Certificate for OpenStack API endpoints</a></h3>
+              <h3 id="tls-certificate-for-openstack-api-endpoints">TLS Certificate for OpenStack API endpoints</h3>
               <p>Your OpenStack cloud may have its API endpoints configured to use HTTPS with self-signed certificates. These work for testing purposes but are problematic for security; they make it difficult for you to ensure that there is no man-in-the-middle attack between your Atmosphere(1) and your OpenStack cloud. Self-signed certificates encourage you to disable certificate validation in your client applications, which is a <strong>bad</strong> security practice.</p>
               <p>So, obtain a TLS/SSL certificate for the hostname you want to use to connect to the OpenStack API. If you don’t have one, you can get free certificates from Let’s Encrypt; perhaps run it on your load balancer(s) or infrastructure node(s).</p>
               <p>Note that the “public” IP address for your OpenStack APIs does not strictly need to be in publicly routable IP space (as long as it is routable from your Atmosphere), but in order to successfully obtain a certificate from Let’s Encrypt, you must expose port 80 or 443 on a public IP address from the host making the request.</p>
-              <h2 id="openstack-configuration"><a href="#openstack-configuration">OpenStack Configuration</a></h2>
+              <h2 id="openstack-configuration">OpenStack Configuration</h2>
               <p>Skip this if you already have an OpenStack deployment configured for use with Atmosphere.</p>
               <p>These instructions are written for OpenStack clouds provisioned with the OpenStack-Ansible project (OSA). If you roll your own cloud or get it from elsewhere, you may need to translate, but the concepts still apply.</p>
-              <h3 id="expose-apis-and-optionally-secure-them-wtih-https"><a href="#expose-apis-and-optionally-secure-them-wtih-https">Expose APIs * (and optionally secure them wtih HTTPS)</a></h3>
+              <h3 id="expose-apis-and-optionally-secure-them-wtih-https">Expose APIs * (and optionally secure them wtih HTTPS)</h3>
               <p>Atmosphere(1) needs access to the public API endpoints for the various OpenStack services (which?), and also to the <em>Keystone admin API</em>. (Possibly also admin APIs for other services, possibly not?)</p>
               <p>These APIs should be configured to use HTTPS only – this is not a strict requirement for testing but should be considered a requirement for any production deployment, especially if API traffic between Atmosphere(1) and OpenStack will transit networks that you don’t trust or control.</p>
               <p>By default, OSA configures public API endpoints with HTTPS using self-signed certificates. This is better than no HTTPS at all, but it’s much better to use real, client-trusted HTTPS certificates.</p>
@@ -182,13 +184,13 @@
               | d39cab53a5d546738aeee36d87115b48 | RegionOne | glance       | image          | True    | public    | https://myawesomecloud.org:9292                                |
               +----------------------------------+-----------+--------------+----------------+---------+-----------+----------------------------------------------------------------+</code></pre>
               <p>You should see HTTPS URLs, with fully qualified domain names (hostnames) instead of IP addresses, for all of the public endpoints, <em>and also for the keystone admin endpoint</em>. If so, you’re good! (If not, you may need to use <code>openstack endpoint delete</code> and <code>openstack endpoint create</code> commands to match reality. Don’t be afraid to <code>curl</code> where you think the endpoints should be, to verify that they are available.)</p>
-              <h3 id="configure-openstack-for-atmosphere-access"><a href="#configure-openstack-for-atmosphere-access">Configure OpenStack for Atmosphere Access *</a></h3>
+              <h3 id="configure-openstack-for-atmosphere-access">Configure OpenStack for Atmosphere Access *</h3>
               <p>Create a keystone user “atmoadmin”, and a project with the same name. Grant the atmoadmin user the “admin” role for the atmoadmin project. (Note that <strong>this gives the atmoadmin user admin rights to the entire OpenStack cloud</strong>.)</p>
               <p>To do this in the OpenStack client tools:</p>
               <pre><code>openstack project create atmoadmin
               openstack user create --password mysupersecretpassword --project atmoadmin atmoadmin
               openstack role add --user atmoadmin --project atmoadmin admin</code></pre>
-              <h3 id="obtain-credentials"><a href="#obtain-credentials">Obtain Credentials *</a></h3>
+              <h3 id="obtain-credentials">Obtain Credentials *</h3>
               <p>Look for your openrc file, which contains information needed to tell Atmosphere how to connect to OpenStack. If you have Horizon dashboard access, you can download the openrc file specific to a project – browse to Project -&gt; “Access &amp; Security” -&gt; “API Access” -&gt; “Download OpenStack RC File v3”. You’ll also find openrc files in /root/ in the utility containers that OSA deploys, and in the deployer’s home folder on the deployment host.</p>
               <p>(CloudLab places this file in <code>/root/setup/admin-openrc-newcli.sh</code>, approximately?)</p>
               <p>An openrc file will look like this (approximately).</p>
@@ -207,8 +209,8 @@
               if [ -z &quot;$OS_REGION_NAME&quot; ]; then unset OS_REGION_NAME; fi
               export OS_INTERFACE=public
               export OS_IDENTITY_API_VERSION=3</code></pre>
-              <h2 id="atmosphere-configuration"><a href="#atmosphere-configuration">Atmosphere Configuration</a></h2>
-              <h4 id="add-a-new-provider"><a href="#add-a-new-provider">Add a New Provider *</a></h4>
+              <h2 id="atmosphere-configuration">Atmosphere Configuration</h2>
+              <h4 id="add-a-new-provider">Add a New Provider *</h4>
               <p>Build some JSON to feed to the add_new_provider.py script. Replace the boilerplate variables here with information from the openrc file and your desired configuration:</p>
               <pre><code>{
                 &quot;admin&quot;: {
@@ -288,7 +290,7 @@
                u&#39;public_routers&#39;: u&#39;public_router&#39;,
                u&#39;region_name&#39;: u&#39;RegionOne&#39;}
               Does everything above look correct? [Yes]/No</code></pre>
-              <h4 id="add-user-accounts-to-the-new-cloud"><a href="#add-user-accounts-to-the-new-cloud">Add User Accounts to the new cloud *</a></h4>
+              <h4 id="add-user-accounts-to-the-new-cloud">Add User Accounts to the new cloud *</h4>
               <p>From the Atmosphere server, grant at least one user an identity on your OpenStack cloud:</p>
               <pre><code>source /opt/env/atmo/bin/activate
               cd /opt/dev/atmosphere
@@ -297,7 +299,7 @@
               # Replace the provider ID to match the provider that you just added
               # The first provider added to a new Atmosphere deployment is typically 4
               python scripts/add_new_accounts.py --provider 4 --users cmart</code></pre>
-              <h4 id="grant-staffsuperuser-privileges"><a href="#grant-staffsuperuser-privileges">Grant Staff/Superuser Privileges</a></h4>
+              <h4 id="grant-staffsuperuser-privileges">Grant Staff/Superuser Privileges</h4>
               <p>This is not strictly part of connecting a cloud provider, but you likely want to grant these privileges to your Atmosphere user account for testing purposes.</p>
               <p>From Atmosphere’s manage.py REPL:</p>
               <pre><code>from core.models import AtmosphereUser
@@ -308,10 +310,10 @@
               user.set_password(&quot;changeme123&quot;)
               user.save()</code></pre>
               <p>If you are not using LDAP or mock authentication, you must also un-comment <code>django.contrib.auth.backends.ModelBackend</code> in the <code>AUTHENTICATION_BACKENDS</code> section of atmosphere/settings/local.py. (This should be configured by Clank in the future).</p>
-              <h4 id="choose-an-allocation-strategy"><a href="#choose-an-allocation-strategy">Choose an Allocation Strategy *</a></h4>
+              <h4 id="choose-an-allocation-strategy">Choose an Allocation Strategy *</h4>
               <p>From Julian’s notes, we should generalize this:</p>
               <ul>
-              <li>When you go to URL: <a href="https://youratmosphere.cloud/admin/core/allocationstrategy/">https://youratmosphere.cloud/admin/core/allocationstrategy/</a></li>
+              <li>When you go to URL: <a href="https://youratmosphere.cloud/admin/core/allocationstrategy/" class="uri">https://youratmosphere.cloud/admin/core/allocationstrategy/</a></li>
               <li>And you log in with the staff account that you just configured, or if mock authentication is enabled, any username and any password
               <ul>
               <li>If you can’t log in, make sure that the user is staff and admin: [Make a user staff and admin][]</li>
@@ -328,9 +330,9 @@
               <li>And you select “Ignore non-active status” from “Rules behaviors”</li>
               <li>And you select “Multiply by Size CPU” from “Rules behaviors”</li>
               <li>And you press the “Save” button</li>
-              <li>Then you should see: “The allocation strategy &quot;Provider:4:your-new-cloud Counting:1 Month - Calendar Window Refresh:[<RefreshBehavior: First of the Month>] Rules:[<RulesBehavior: Ignore non-active status>, <RulesBehavior: Multiply by Size CPU>]&quot; was added successfully.”</li>
+              <li>Then you should see: “The allocation strategy &quot;Provider:4:your-new-cloud Counting:1 Month - Calendar Window Refresh:[&lt;RefreshBehavior: First of the Month&gt;] Rules:[&lt;RulesBehavior: Ignore non-active status&gt;, &lt;RulesBehavior: Multiply by Size CPU&gt;]&quot; was added successfully.”</li>
               </ul>
-              <h4 id="add-openstacks-imagesinstancessizes-to-atmosphere"><a href="#add-openstacks-imagesinstancessizes-to-atmosphere">Add OpenStack’s Images/Instances/Sizes to Atmosphere *</a></h4>
+              <h4 id="add-openstacks-imagesinstancessizes-to-atmosphere">Add OpenStack’s Images/Instances/Sizes to Atmosphere *</h4>
               <p>From your Atmosphere server:</p>
               <pre><code>cd /opt/dev/atmosphere
               . /opt/env/atmo/bin/activate
@@ -342,7 +344,7 @@
               monitor_sizes_for(8)
               monitor_machines_for(8)
               monitor_instances_for(8)  # Only necessary if `nova boot` was done out-of-band</code></pre>
-              <h4 id="update-atmosphere-ansible-hosts-file-and-group_vars"><a href="#update-atmosphere-ansible-hosts-file-and-group_vars">Update atmosphere-ansible hosts file and group_vars *</a></h4>
+              <h4 id="update-atmosphere-ansible-hosts-file-and-group_vars">Update atmosphere-ansible hosts file and group_vars *</h4>
               <p>Ensure that the hostnames of all your VMs are in <code>/opt/dev/atmosphere-ansible/ansible/hosts</code>, e.g.:</p>
               <pre><code>[atmosphere:children]
               atmosphere-mytestcloud
@@ -350,7 +352,7 @@
               [atmosphere-mytestcloud]
               vm7.mytestcloud.cyverse.org ansible_host=128.196.171.7 ansible_port=22</code></pre>
               <p>Also ensure that you have appropriate group_vars defined in <code>/opt/dev/atmosphere-ansible/ansible/group_vars/name-of-your-cloud</code>.</p>
-              <h4 id="test-atmosphere"><a href="#test-atmosphere">Test Atmosphere!</a></h4>
+              <h4 id="test-atmosphere">Test Atmosphere!</h4>
               <p>In Atmosphere, try logging into the Troposphere UI as the account you added, selecting an image, and launching an instance.</p>
               </article>
             </div> <!-- #main -->

--- a/dist/gateone_background.html
+++ b/dist/gateone_background.html
@@ -8,9 +8,9 @@
         <meta http-equiv="Content-Style-Type" content="text/css" />
         <meta name="generator" content="pandoc" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-                    <title></title>
+                    <title>gateone_background</title>
         <style type="text/css">code{white-space: pre;}</style>
-                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" type="text/css" />
+                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" />
                     <link rel="icon" href="themes/cyverse/media/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" href="themes/cyverse/media/css/normalize.min.css">
         <link rel="stylesheet" href="themes/cyverse/media/css/main.css">
@@ -43,8 +43,8 @@
                       </ul></li>
                       <li><a href="#how-is-gateone-deployed">How is GateOne Deployed?</a><ul>
                       <li><a href="#ansible">Ansible</a><ul>
-                      <li><a href="#httpsgithub.comcyversegateone-server-ansible"><a href="https://github.com/cyverse/gateone-server-ansible">https://github.com/cyverse/gateone-server-ansible</a></a></li>
-                      <li><a href="#httpsgithub.comcyverse-ansibleansible-gateone-server"><a href="https://github.com/cyverse-ansible/ansible-gateone-server">https://github.com/cyverse-ansible/ansible-gateone-server</a></a></li>
+                      <li><a href="#httpsgithub.comcyversegateone-server-ansible"><a href="https://github.com/cyverse/gateone-server-ansible" class="uri">https://github.com/cyverse/gateone-server-ansible</a></a></li>
+                      <li><a href="#httpsgithub.comcyverse-ansibleansible-gateone-server"><a href="https://github.com/cyverse-ansible/ansible-gateone-server" class="uri">https://github.com/cyverse-ansible/ansible-gateone-server</a></a></li>
                       </ul></li>
                       <li><a href="#customizations">Customizations</a></li>
                       </ul></li>
@@ -68,19 +68,19 @@
                   </aside>
                               <!-- MAIN CONTENT -->
               <article>
-              <h1 id="gateone-background"><a href="#gateone-background">GateOne Background</a></h1>
-              <h2 id="what-is-gateone"><a href="#what-is-gateone">What is GateOne?</a></h2>
+              <h1 id="gateone-background">GateOne Background</h1>
+              <h2 id="what-is-gateone">What is GateOne?</h2>
               <p>It’s a web shell, aka terminal, emulator &amp; SSH client that uses HTML5 technologies. - another way to put it, it uses pure HTML, JavaScript and web sockets</p>
               <p>The underlying technologies? - Python + Tornado web server - JavaScript - nginx</p>
-              <h2 id="how-do-we-use-it"><a href="#how-do-we-use-it">How do we use it?</a></h2>
+              <h2 id="how-do-we-use-it">How do we use it?</h2>
               <p>We offer a web shell to instances in the cloud via GateOne. It appears as a view within Django [0] - the resources of GateOne as “included” and render as <em>embedded</em>. This impacts <em>how</em> the associated GateOne resources are served; if they’re served from a domain different from Troposphere - then Cross-Origin Resource Sharing (CORS) would be happening [1]</p>
-              <h2 id="how-does-it-know-we-are-a-valid-request-origin"><a href="#how-does-it-know-we-are-a-valid-request-origin">How does it know we are a valid request origin?</a></h2>
+              <h2 id="how-does-it-know-we-are-a-valid-request-origin">How does it know we are a valid request origin?</h2>
               <p>There are two aspects required here:</p>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li>An API key and secret that both Troposphere &amp; GateOne know <em>about</em></li>
               <li>A white-list of valid <em>origins</em></li>
               </ol>
-              <h3 id="keysecret"><a href="#keysecret">Key/Secret</a></h3>
+              <h3 id="keysecret">Key/Secret</h3>
               <p>GateOne has an Authenticated API [2]. You generate an API key and secret [3], then use them to create an HMAC signature of the required authentication info:</p>
               <pre><code>authobj = {
                 &#39;api_key&#39;: &#39;MjkwYzc3MDI2MjhhNGZkNDg1MjJkODgyYjBmN2MyMTM4M&#39;,
@@ -90,10 +90,10 @@
                 &#39;signature_method&#39;: &#39;HMAC-SHA1&#39;,
                 &#39;api_version&#39;: &#39;1.0&#39;
               }</code></pre>
-              <p>source: <a href="https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html#generate-an-auth-object">https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html#generate-an-auth-object</a></p>
+              <p>source: <a href="https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html#generate-an-auth-object" class="uri">https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html#generate-an-auth-object</a></p>
               <p>You can find this key and secret within the GateOne configration file <code>30api_keys.conf</code> [4]</p>
               <p>Note, the <code>upn</code> value was what previous prevented us from <em>emulating</em> a user.</p>
-              <h3 id="origin"><a href="#origin">Origin</a></h3>
+              <h3 id="origin">Origin</h3>
               <p>The allowed <code>origins</code> is a JSON array of either hostname or IP that are accepted.</p>
               <p><code>origins</code> appears in the <code>10server.conf</code> file [5]</p>
               <pre><code>// This is Gate One&#39;s main settings file.
@@ -115,26 +115,26 @@
               }</code></pre>
               <p>Note, all configuration for deployed GateOne servers appears under: <code>/etc/gateone/conf.d</code></p>
               <p>These are symlinks into the <code>/opt/gateone-config</code> directory.</p>
-              <h2 id="how-is-gateone-deployed"><a href="#how-is-gateone-deployed">How is GateOne Deployed?</a></h2>
+              <h2 id="how-is-gateone-deployed">How is GateOne Deployed?</h2>
               <p>For Atmosphere(0) and Jetstream Cloud, GateOne and Atmosphere(1) are implemented on separate servers. (This may not be a strict requirement.)</p>
-              <h3 id="ansible"><a href="#ansible">Ansible</a></h3>
+              <h3 id="ansible">Ansible</h3>
               <p>There are currently two different sets of Ansible code that deploy GateOne.</p>
-              <h4 id="httpsgithub.comcyversegateone-server-ansible"><a href="#httpsgithub.comcyversegateone-server-ansible"><a href="https://github.com/cyverse/gateone-server-ansible">https://github.com/cyverse/gateone-server-ansible</a></a></h4>
+              <h4 id="httpsgithub.comcyversegateone-server-ansible"><a href="https://github.com/cyverse/gateone-server-ansible" class="uri">https://github.com/cyverse/gateone-server-ansible</a></h4>
               <p>gateone-server-ansible was used to implement Jetstream Cloud’s production GateOne. It has a few requirements:</p>
               <ul>
               <li>requires you to symlink to /etc/ansible/roles</li>
               <li>Assumes that SSL certificate and private key are already deployed to target server</li>
               <li>requires you to store your GateOne configuration in a separate repository</li>
               </ul>
-              <h4 id="httpsgithub.comcyverse-ansibleansible-gateone-server"><a href="#httpsgithub.comcyverse-ansibleansible-gateone-server"><a href="https://github.com/cyverse-ansible/ansible-gateone-server">https://github.com/cyverse-ansible/ansible-gateone-server</a></a></h4>
+              <h4 id="httpsgithub.comcyverse-ansibleansible-gateone-server"><a href="https://github.com/cyverse-ansible/ansible-gateone-server" class="uri">https://github.com/cyverse-ansible/ansible-gateone-server</a></h4>
               <p>ansible-gateone-server is a newer, modular Ansible role that is published on (and consumable from) Ansible Galaxy. It is used to implement GateOne for the Jetstream test cloud. ansible-gateone-server is self-contained: it does not require separate repos for your GateOne configuration files, instead you can define your configuration as Ansible variables. ansible-gateone-server will also deploy your SSL certificate and private key - in this way, it is a “batteries-included” way to implement a working GateOne on a brand new server.</p>
-              <h3 id="customizations"><a href="#customizations">Customizations</a></h3>
+              <h3 id="customizations">Customizations</h3>
               <p>We currently operate off of a fork of GateOne:</p>
-              <p><a href="https://github.com/edwins/GateOne">https://github.com/edwins/GateOne</a></p>
+              <p><a href="https://github.com/edwins/GateOne" class="uri">https://github.com/edwins/GateOne</a></p>
               <p>This is fork includes added functionality for having a “global” SSH config file. This file appears as a symlink under <code>/etc/gateone/conf.d</code> and links to: <code>/opt/gateone-config/ssh_config_global</code>. Efforts to get this modification included by the GateOne project are underway.</p>
               <p>Both of the Ansible options deploy this fork of GateOne, by default.</p>
-              <h2 id="troubleshooting-background"><a href="#troubleshooting-background">Troubleshooting Background</a></h2>
-              <h3 id="resource-serving"><a href="#resource-serving">Resource Serving</a></h3>
+              <h2 id="troubleshooting-background">Troubleshooting Background</h2>
+              <h3 id="resource-serving">Resource Serving</h3>
               <p>We currently put Nginx in front of GateOne. GateOne serves resources via an Nginx location defined in under <code>/etc/nginx/locations</code></p>
               <pre><code>location /gateone {
                 #Listed as /gateone
@@ -150,7 +150,7 @@
                 proxy_set_header Connection &quot;upgrade&quot;;
               }</code></pre>
               <p>Note: the “Connection” header is present to allow for Web Socket connections</p>
-              <h3 id="service-operation"><a href="#service-operation">Service Operation</a></h3>
+              <h3 id="service-operation">Service Operation</h3>
               <p>You can verify that GateOne is running using <code>service</code>:</p>
               <pre><code>$ service gateone status
               gateone start/running, process 12634&lt;/pre&gt;</code></pre>
@@ -158,7 +158,7 @@
               <p>Because Nginx makes GateOne available to the outside world, you’d want to ensure that it was running as well:</p>
               <pre><code>service nginx status
               nginx start/running, process 8818</code></pre>
-              <h3 id="ports"><a href="#ports">Ports</a></h3>
+              <h3 id="ports">Ports</h3>
               <p>Ensure that GateOne is bound to the internal port for reverse proxying (e.g. 8443) and that Nginx is listening on the HTTPS port (e.g. 443):</p>
               <pre><code>root@myserver:/etc/gateone/conf.d# netstat -lntp
               Active Internet connections (only servers)
@@ -175,7 +175,7 @@
               tcp6       0      0 :::8443                 :::*                    LISTEN      8821/python     
               tcp6       0      0 :::5666                 :::*                    LISTEN      10622/nrpe</code></pre>
               <p>Also ensure that communications are not blocked by ufw/iptables/firewalld on the host, nor by a border firewall on the hosting facility / campus network.</p>
-              <h3 id="logs"><a href="#logs">Logs</a></h3>
+              <h3 id="logs">Logs</h3>
               <p>All logs associated with GateOne are under <code>/var/log/gateone/</code></p>
               <p>You can change the logging level in <code>/etc/gateone/conf.d/10server.conf</code></p>
               <pre><code>// This is Gate One&#39;s main settings file.
@@ -193,12 +193,12 @@
               <pre><code>[I 160502 13:50:04 server:2223] User lenards authenticated successfully via origin atmobeta.myexample.org (location 128-196-65-166).
               [I 160502 13:53:14 server:1765] {&quot;ip_address&quot;: &quot;127.0.0.1&quot;, &quot;location&quot;: &quot;128-196-65-166&quot;, &quot;upn&quot;: &quot;lenards&quot;} WebSocket closed (lenards 127.0.0.1).</code></pre>
               <p>You’d also want to investigate nginx’s logs as well (<code>/var/log/nginx</code>), notably the error.log.</p>
-              <h3 id="keys-connecting-the-dots"><a href="#keys-connecting-the-dots">Keys &amp; connecting the dots…</a></h3>
+              <h3 id="keys-connecting-the-dots">Keys &amp; connecting the dots…</h3>
               <p>Atmosphere generates a default SSH key per user and places this key on the GateOne server. It is used for password-less connections to instances. When an instance is launched, this default key will be included.</p>
               <p>If you’re troubleshooting, you may want to look for the presence of a key. You can find them under <code>/var/lib/gateone/{{atmosphere_username}}/.ssh</code>.</p>
-              <h3 id="dtach"><a href="#dtach">dtach</a></h3>
+              <h3 id="dtach">dtach</h3>
               <p>This process helps preserve the state of a GateOne session (it appears as <code>dtach</code> in <code>ps aux</code>)</p>
-              <p><a href="https://github.com/bogner/dtach">https://github.com/bogner/dtach</a></p>
+              <p><a href="https://github.com/bogner/dtach" class="uri">https://github.com/bogner/dtach</a></p>
               <p>You can look for a user’s session by IP:</p>
               <pre><code># ps aux | grep dtach | grep &#39;128-196-64-13&#39;
               root 6509 0.0 0.0 4400 608 pts/33 Ss+ Oct03 0:00 /bin/sh -c dtach -c /tmp/gateone-api/MmFjYmU5OTgzZTJiNGY0ZjliNjg4OTZkYTNiY2MxNzQ0Z/dtach_128-196-64-13_1 -E -z -r none /usr/local/lib/python2.7/dist-packages/gateone-1.2.0-py2.7.egg/gateone/applications/terminal/plugins/ssh/scripts/ssh_connect.py -S &#39;/tmp/gateone-api/MmFjYmU5OTgzZTJiNGY0ZjliNjg4OTZkYTNiY2MxNzQ0Z/%SHORT_SOCKET%&#39; --sshfp --config &#39;/etc/gateone/conf.d/ssh_config_global&#39;; sleep .1
@@ -207,15 +207,15 @@
               root 27455 0.0 0.0 4400 612 pts/14 Ss+ Oct03 0:00 /bin/sh -c dtach -c /tmp/gateone-api/MzAwMzZhNGNhYjJjNGRhZWEyNzU5ZWVkMjBkYWY0ZjBlZ/dtach_128-196-64-13_1 -E -z -r none /usr/local/lib/python2.7/dist-packages/gateone-1.2.0-py2.7.egg/gateone/applications/terminal/plugins/ssh/scripts/ssh_connect.py -S &#39;/tmp/gateone-api/MzAwMzZhNGNhYjJjNGRhZWEyNzU5ZWVkMjBkYWY0ZjBlZ/%SHORT_SOCKET%&#39; --sshfp --config &#39;/etc/gateone/conf.d/ssh_config_global&#39;; sleep .1
               root 27456 0.0 0.0 6228 364 pts/14 S+ Oct03 0:00 dtach -c /tmp/gateone-api/MzAwMzZhNGNhYjJjNGRhZWEyNzU5ZWVkMjBkYWY0ZjBlZ/dtach_128-196-64-13_1 -E -z -r none /usr/local/lib/python2.7/dist-packages/gateone-1.2.0-py2.7.egg/gateone/applications/terminal/plugins/ssh/scripts/ssh_connect.py -S /tmp/gateone-api/MzAwMzZhNGNhYjJjNGRhZWEyNzU5ZWVkMjBkYWY0ZjBlZ/%SHORT_SOCKET% --sshfp --config /etc/gateone/conf.d/ssh_config_global
               root 27457 0.0 0.0 14792 708 ? Ss Oct03 0:00 dtach -c /tmp/gateone-api/MzAwMzZhNGNhYjJjNGRhZWEyNzU5ZWVkMjBkYWY0ZjBlZ/dtach_128-196-64-13_1 -E -z -r none /usr/local/lib/python2.7/dist-packages/gateone-1.2.0-py2.7.egg/gateone/applications/terminal/plugins/ssh/scripts/ssh_connect.py -S /tmp/gateone-api/MzAwMzZhNGNhYjJjNGRhZWEyNzU5ZWVkMjBkYWY0ZjBlZ/%SHORT_SOCKET% --sshfp --config /etc/gateone/conf.d/ssh_config_global</code></pre>
-              <h2 id="troubleshooting-specifics"><a href="#troubleshooting-specifics">Troubleshooting Specifics</a></h2>
-              <h3 id="welcome-to-nginx-page"><a href="#welcome-to-nginx-page">Welcome to nginx “page”</a></h3>
+              <h2 id="troubleshooting-specifics">Troubleshooting Specifics</h2>
+              <h3 id="welcome-to-nginx-page">Welcome to nginx “page”</h3>
               <p>This is a misconfigured deployment of Troposphere</p>
-              <h3 id="troposphere-source-not-in-origins"><a href="#troposphere-source-not-in-origins">Troposphere “source” not in <code>origins</code></a></h3>
+              <h3 id="troposphere-source-not-in-origins">Troposphere “source” not in <code>origins</code></h3>
               <p>Click to accept SSL Certificate …</p>
               <p>White screen with black background messages</p>
-              <h3 id="gateone-is-not-defined"><a href="#gateone-is-not-defined">GateOne is not defined</a></h3>
+              <h3 id="gateone-is-not-defined">GateOne is not defined</h3>
               <p>This means that either the GateOne service is down or not responding.</p>
-              <h2 id="generating-a-new-api-key-secret"><a href="#generating-a-new-api-key-secret">Generating a new API key &amp; secret</a></h2>
+              <h2 id="generating-a-new-api-key-secret">Generating a new API key &amp; secret</h2>
               <p>The documentation of GateOne still refers to the utility executable as <code>./gateone.py</code>. It is is <code>./run_gateone.py</code> (in <a href="https://github.com/edwins/GateOne/">our fork</a>, and in <a href="https://github.com/liftoff/GateOne/tree/master">master</a>).</p>
               <pre><code># python run_gateone.py --help
               Usage: run_gateone.py [OPTIONS]</code></pre>
@@ -240,14 +240,14 @@
                       }
                   }
               }</code></pre>
-              <h2 id="references"><a href="#references">References</a></h2>
+              <h2 id="references">References</h2>
               <ul>
-              <li>0 <a href="https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/troposphere/views/web_shell.py">https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/troposphere/views/web_shell.py</a></li>
-              <li>1 <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS">https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS</a></li>
-              <li>2 <a href="https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html">https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html</a></li>
-              <li>3 <a href="https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html#generate-an-api-key-secret">https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html#generate-an-api-key-secret</a></li>
-              <li>4 below <em>note</em>, <a href="https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html#generate-an-api-key-secret">https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html#generate-an-api-key-secret</a></li>
-              <li>5 <a href="https://liftoff.github.io/GateOne/About/configuration.html">https://liftoff.github.io/GateOne/About/configuration.html</a></li>
+              <li>0 <a href="https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/troposphere/views/web_shell.py" class="uri">https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/troposphere/views/web_shell.py</a></li>
+              <li>1 <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS" class="uri">https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS</a></li>
+              <li>2 <a href="https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html" class="uri">https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html</a></li>
+              <li>3 <a href="https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html#generate-an-api-key-secret" class="uri">https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html#generate-an-api-key-secret</a></li>
+              <li>4 below <em>note</em>, <a href="https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html#generate-an-api-key-secret" class="uri">https://liftoff.github.io/GateOne/Developer/embedding_api_auth.html#generate-an-api-key-secret</a></li>
+              <li>5 <a href="https://liftoff.github.io/GateOne/About/configuration.html" class="uri">https://liftoff.github.io/GateOne/About/configuration.html</a></li>
               </ul>
               </article>
             </div> <!-- #main -->

--- a/dist/getting_started.html
+++ b/dist/getting_started.html
@@ -8,9 +8,9 @@
         <meta http-equiv="Content-Style-Type" content="text/css" />
         <meta name="generator" content="pandoc" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-                    <title></title>
+                    <title>00_terminology</title>
         <style type="text/css">code{white-space: pre;}</style>
-                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" type="text/css" />
+                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" />
                     <link rel="icon" href="themes/cyverse/media/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" href="themes/cyverse/media/css/normalize.min.css">
         <link rel="stylesheet" href="themes/cyverse/media/css/main.css">
@@ -61,10 +61,10 @@
                   </aside>
                               <!-- MAIN CONTENT -->
               <article>
-              <h1 id="getting-started"><a href="#getting-started">Getting Started</a></h1>
+              <h1 id="getting-started">Getting Started</h1>
               <p>We’re going to go over some simple terminology and concepts commonly used in Atmosphere.</p>
-              <h2 id="terminology---atmosphere"><a href="#terminology---atmosphere">Terminology - Atmosphere</a></h2>
-              <h3 id="user"><a href="#user">User</a></h3>
+              <h2 id="terminology---atmosphere">Terminology - Atmosphere</h2>
+              <h3 id="user">User</h3>
               <p>A User is an individual that has logged into Atmosphere.</p>
               <p>Users have:</p>
               <ul>
@@ -72,7 +72,7 @@
               <li>Name</li>
               <li>Email</li>
               </ul>
-              <h3 id="group"><a href="#group">Group</a></h3>
+              <h3 id="group">Group</h3>
               <p>Groups are used similar to the linux “user/group” model.</p>
               <ul>
               <li>A Group of one will exist for each User.</li>
@@ -80,7 +80,7 @@
               <li>Users can be in more than one Group at once</li>
               <li>Groups (not Users) are the “owners” of cloud resources</li>
               </ul>
-              <h3 id="provider"><a href="#provider">Provider</a></h3>
+              <h3 id="provider">Provider</h3>
               <p>Provider (also known as cloud, cloud provider) is a term used by atmosphere to identify a specific installation of cloud software.</p>
               <ul>
               <li>Providers have a specific set of credentials common to all users (That uniquely identifies them)
@@ -93,7 +93,7 @@
               </ul></li>
               <li>Providers are owned by a Group (usually a staff/admin)</li>
               </ul>
-              <h3 id="identity"><a href="#identity">Identity</a></h3>
+              <h3 id="identity">Identity</h3>
               <p>Identities are a term used by atmosphere to identify a specific user on a Provider.</p>
               <ul>
               <li>Identities have a specific set of credentials for the user
@@ -102,47 +102,53 @@
               </ul></li>
               <li>Identities are owned by a Group</li>
               </ul>
-              <h3 id="projects"><a href="#projects">Projects</a></h3>
+              <h3 id="projects">Projects</h3>
               <p>Projects (in Atmosphere) represent a collection of Cloud Resources (not sizes) that allow users to logically group related instances/volumes.</p>
               <ul>
               <li>A project is required for new instance/volume created in Atmosphere.</li>
               <li>Projects have a name</li>
               <li>Projects are owned by a Group</li>
               </ul>
-              <h3 id="application"><a href="#application">Application</a></h3>
+              <h3 id="application">Application</h3>
               <p>Applications (displayed to the user in troposphere as Image) are a way to abstract a “history” of related Machines (via ApplicationVersion).</p>
               <p>Ex:</p>
               <table>
+              <colgroup>
+              <col style="width: 25%" />
+              <col style="width: 25%" />
+              <col style="width: 25%" />
+              <col style="width: 25%" />
+              </colgroup>
               <thead>
               <tr class="header">
-              <th align="left">Image Name in OpenStack</th>
-              <th align="left">Application</th>
-              <th align="left">ApplicationVersion</th>
-              <th align="left">ProviderMachines</th>
+              <th>Image Name in OpenStack</th>
+              <th>Application</th>
+              <th>ApplicationVersion</th>
+              <th>ProviderMachines</th>
               </tr>
               </thead>
               <tbody>
               <tr class="odd">
-              <td align="left">Ubuntu 16.04 v1 (1111-222-333-4444)</td>
-              <td align="left">1 - Ubuntu 16.04</td>
-              <td align="left">1.0</td>
-              <td align="left">Tucson Cloud (1111-222-333-4444)</td>
+              <td>Ubuntu 16.04 v1 (1111-222-333-4444)</td>
+              <td>1 - Ubuntu 16.04</td>
+              <td>1.0</td>
+              <td>Tucson Cloud (1111-222-333-4444)</td>
               </tr>
               <tr class="even">
-              <td align="left">Ubuntu 16.04 v1 (1111-222-333-4444)</td>
-              <td align="left">1 - Ubuntu 16.04</td>
-              <td align="left">1.0</td>
-              <td align="left">Austin Cloud (1111-222-333-4444)</td>
+              <td>Ubuntu 16.04 v1 (1111-222-333-4444)</td>
+              <td>1 - Ubuntu 16.04</td>
+              <td>1.0</td>
+              <td>Austin Cloud (1111-222-333-4444)</td>
               </tr>
               <tr class="odd">
-              <td align="left">Ubuntu 16.04 v2 (2222-333-444-5555)</td>
-              <td align="left">1 - Ubuntu 16.04</td>
-              <td align="left">2.0</td>
-              <td align="left">Tucson Cloud (2222-333-444-5555)</td>
+              <td>Ubuntu 16.04 v2 (2222-333-444-5555)</td>
+              <td>1 - Ubuntu 16.04</td>
+              <td>2.0</td>
+              <td>Tucson Cloud (2222-333-444-5555)</td>
               </tr>
               </tbody>
               </table>
-              <h3 id="applicationversion"><a href="#applicationversion">ApplicationVersion</a></h3>
+              <h3 id="applicationversion">ApplicationVersion</h3>
               <p>ApplicationVersion (also known as Version) is a grouping of one or more Machines.</p>
               <p>(In Atmosphere, it is common to replicate a Machine (ex: Ubuntu 16.04) across several Providers (ex: iPlant - Austin, iPlant - Tucson, …).)</p>
               <p>Because the image is (mostly) identical across providers, the grouping serves as a way to simplify the cloud-agnostic nature of Atmosphere.</p>
@@ -151,10 +157,10 @@
               <li>ApplicationVersions have a name (1.0, 2.0-alpha, beta-do-not-use, …)</li>
               <li>ApplicationVersions have a change log (that helps users understand what changed between versions)</li>
               </ul>
-              <h2 id="terminology---cloud"><a href="#terminology---cloud">Terminology - Cloud</a></h2>
-              <h3 id="cloud-resource"><a href="#cloud-resource">Cloud resource</a></h3>
+              <h2 id="terminology---cloud">Terminology - Cloud</h2>
+              <h3 id="cloud-resource">Cloud resource</h3>
               <p>Cloud Resources are a term used by atmosphere to identify a Volume, Instance, Size, or Machine.</p>
-              <h3 id="size"><a href="#size">Size</a></h3>
+              <h3 id="size">Size</h3>
               <p>Sizes (also known as flavors in Openstack) are a preset configuration of CPUs, GB of memory, and Disk space that will be allocated to a Machine when creating an Instance.</p>
               <p>Sizes have:</p>
               <ul>
@@ -163,7 +169,7 @@
               <li>Disk (for the image, in GB, 0 means “create disk image that is the exact size of the Machine”)</li>
               <li>Ephemeral (as an additional mount, in GB)</li>
               </ul>
-              <h3 id="machine"><a href="#machine">Machine</a></h3>
+              <h3 id="machine">Machine</h3>
               <p>Machines (also known as Image, or ProviderMachine) are like a blueprint that will tell the Cloud how to create a new Instance.</p>
               <ul>
               <li>Machines, minimally, have an operating system</li>
@@ -171,7 +177,7 @@
               <li>They are a fixed size (usually 8GB-60GB)</li>
               <li>Administrators and other users can create new machines from Instances via <a href="#concepts-machine_requests">Machine Requests</a> and/or downloading new image files.</li>
               </ul>
-              <h3 id="volume"><a href="#volume">Volume</a></h3>
+              <h3 id="volume">Volume</h3>
               <p>Volumes are how users can allocate additional data storage (by policy, up to 1TB) to be used with their instances.</p>
               <ul>
               <li>Volumes have a pre-set size (1-1000gb)</li>
@@ -181,20 +187,20 @@
               </ul></li>
               <li>Can be created based on an Image and “Booted” as an instance. (Bootable volumes are not yet a part of atmosphere)</li>
               </ul>
-              <h3 id="instance"><a href="#instance">Instance</a></h3>
+              <h3 id="instance">Instance</h3>
               <p>Instances (also known as nodes, or servers) is the virtual machine that will be created by end users.</p>
               <ul>
               <li>Instances have a specific size</li>
               <li>Instances are based on an Image or Volume.</li>
               <li>Atmosphere handles the networking and pre-configuration of instances prior to handing control over to the User.</li>
               </ul>
-              <h2 id="concepts-in-atmosphere-and-openstack"><a href="#concepts-in-atmosphere-and-openstack">Concepts in Atmosphere and Openstack</a></h2>
-              <h3 id="concept-quota-and-allocation"><a href="#concept-quota-and-allocation">Concept: Quota and Allocation</a></h3>
+              <h2 id="concepts-in-atmosphere-and-openstack">Concepts in Atmosphere and Openstack</h2>
+              <h3 id="concept-quota-and-allocation">Concept: Quota and Allocation</h3>
               <p>Quotas are an admin-set limit on the number of resources a specific cloud user can create at any one time. - (Ex: Quota of 2 CPU, 8 GB ram) Allocations are a way for Atmosphere to track the amount of time a specific cloud user has used their resource. - (Ex: Allocation for 168 hours of compute in one month)</p>
-              <h3 id="conecpt-machine-requests-imaging"><a href="#conecpt-machine-requests-imaging">Conecpt: Machine Requests (Imaging)</a></h3>
+              <h3 id="conecpt-machine-requests-imaging">Conecpt: Machine Requests (Imaging)</h3>
               <p>When a user launches an instance and configures it to their liking, they can create a MachineRequest that will alert staff users to their desire to create a new Machine. Staff members can then accept/reject the request which will start an automated, asynchronous “imaging” process.</p>
               <p>During the imaging process: - The ‘machine’ is created: - Create and Download a snapshot of the Instance - Mount and clean the image file to remove “User-specific” data - Upload new image to cloud - The ‘machine’ is processed: - Appropriate metadata is attached to the new image - Atmosphere properly catalogs the image into the right Application, Version, and ProviderMachine. - The ‘machine’ is validated: - Atmosphere will launch the instance and wait for it to go to “green-light active”. - Atmosphere will then destroy the launched instance - The ‘machine’ is completed: - The ‘machine owner’ is e-mailed - The machine is ready for launch by others.</p>
-              <h3 id="concept-projects"><a href="#concept-projects">Concept: Projects</a></h3>
+              <h3 id="concept-projects">Concept: Projects</h3>
               <p>Project is an overloaded term, at any one time it could be referring to: - Atmosphere Project : A collection of Cloud Resources. - OpenStack “project” aka Tenant: A grouping of users inside OpenStack - TACC/Xsede project: A collection of TACC/Xsede users.</p>
               </article>
             </div> <!-- #main -->

--- a/dist/imaging_guide.html
+++ b/dist/imaging_guide.html
@@ -8,9 +8,9 @@
         <meta http-equiv="Content-Style-Type" content="text/css" />
         <meta name="generator" content="pandoc" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-                    <title></title>
+                    <title>00_starting</title>
         <style type="text/css">code{white-space: pre;}</style>
-                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" type="text/css" />
+                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" />
                     <link rel="icon" href="themes/cyverse/media/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" href="themes/cyverse/media/css/normalize.min.css">
         <link rel="stylesheet" href="themes/cyverse/media/css/main.css">
@@ -45,16 +45,16 @@
                               <!-- MAIN CONTENT -->
               <article>
               <p>This will take you through how to create a machine request in Troposphere.</p>
-              <h1 id="imaging-and-machine-requests"><a href="#imaging-and-machine-requests">Imaging and Machine Requests</a></h1>
+              <h1 id="imaging-and-machine-requests">Imaging and Machine Requests</h1>
               <p>An image is a type of template for a virtual machine.</p>
               <p>Images are created by launching an instance, installing the software and files that you want to use, and creating a Machine Request. After the image is created, you will be able to launch instances of it. This makes it easier to create reproducible science or distribute commonly used software to other users.</p>
               <p>Images save resources, since you can relaunch an instance of your image at any time instead of having to keep the instance running when you don’t need to use it.</p>
               <p>After submitting your form, the support staff may review your submission and ask for additional information before approving the request.</p>
               <p>Advanced functionality optionally included in your Machine Request: * Include ‘Licensing’ information that will inform users intending to launch your image what is implied and agreed upon. * Include ‘Boot Scripts’ that will allow you to make changes for each user who launches your image at run time. (For example: To update the permissions to the launching user)</p>
-              <h1 id="before-you-create-your-machine-request"><a href="#before-you-create-your-machine-request">Before you create your machine request!</a></h1>
+              <h1 id="before-you-create-your-machine-request">Before you create your machine request!</h1>
               <p>These steps must be completed in order to ensure the image that is created is compatible with Atmosphere: * Remove any non-purchased, licensed software that does not allow for free and open use in the cloud. * Software in which the licensing otherwise prevents the use within a cloud or virtualized environment. * Do <em>NOT</em> install software in these directories, as they will be destroyed during the imaging process: * * /home/ - All files, directories, and icons located under /home/<username>/Desktop will be deleted. To preserve them, you can use /etc/skel which is the directory that will be <em>COPIED</em> to <em>each new user</em> of the VM. Note that these should be small files or starter directories. * * /mnt * * /tmp * * /var/log - All files and directories will be <em>emptied</em> but not destroyed, as part of the imaging process. * * /root - All files and directories under /root/ will be destroyed as part of the imaging process. * Volumes will <em>NOT</em> be copied to a new image. The files must exist on the disk. * Modifications to these files will be destroyed as part of the imaging process: * * /etc/fstab * * /etc/fstaf * * /etc/group * * /etc/host.allow * * /etc/host.conf * * /etc/host.deny * * /etc/hosts * * /etc/ldap.conf * * /etc/passwd * * /etc/resolve.conf * * /etc/shadow * * /etc/sshd/ * * /etc/sysconfig/iptables * If you install software that logs <em>outside</em> of /var/log, be sure to <em>empty the file</em> especially if it contains secrets or otherwise confidential information about your account <em>prior</em> to making a Machine Request for imaging. * NOTE: The permissions of the operating system are NOT affected by the imaging process. If you install software as <code>username:groupname</code> and you intend to provide that software to other users who launch your image, you will need to <em>include a Boot Script</em> that will change the permissions of the directory.</p>
-              <h1 id="creating-a-machine-request"><a href="#creating-a-machine-request">Creating a Machine Request</a></h1>
-              <ol style="list-style-type: decimal">
+              <h1 id="creating-a-machine-request">Creating a Machine Request</h1>
+              <ol type="1">
               <li>Click Projects on the menu bar and open the project with the instance to use for the new image.</li>
               <li>Click the instance name. The instance must be in Active status.</li>
               <li>In the Actions list on the right, click Image.</li>
@@ -65,7 +65,7 @@
               <li>Description of the Image: Enter the description of the image as it will appear in Atmosphere. The description should include key words that concisely describe the tools installed, the purpose of the tools (e.g., This image performs X analysis), and the initial intent of the machine image (e.g. designed for XYZ workshop).</li>
               <li>Image Tags: (Optional) Click in the field and select tags that will enhance search results for this image. You can add and remove tags later, if needed.</li>
               </ul>
-              <ol start="5" style="list-style-type: decimal">
+              <ol start="5" type="1">
               <li>Click Next.</li>
               <li>In the second screen:</li>
               </ol>
@@ -73,14 +73,14 @@
               <li>New Version Name: Enter the new (unique) name or number of the tool to distinguish this tool from others with a similar name.</li>
               <li>Change Log: Enter a brief description of the changes you made to this version of the tool.</li>
               </ul>
-              <ol start="7" style="list-style-type: decimal">
+              <ol start="7" type="1">
               <li>Click Next.</li>
               <li>In the Cloud for Deployment screen:</li>
               </ol>
               <ul>
               <li>Select the cloud provider to use for the image. The choices depend on the providers to which you have been granted access.</li>
               </ul>
-              <ol start="9" style="list-style-type: decimal">
+              <ol start="9" type="1">
               <li>Click Next.</li>
               <li>In the Image Visibility screen:</li>
               </ol>
@@ -90,7 +90,7 @@
               <li>Private: Allows only you to view and launch the image.</li>
               <li>Specific Users: Makes the image visible to and launchable only specified users. If you chose Specific Users, select the users who will be able to launch the image.</li>
               </ul>
-              <ol start="11" style="list-style-type: decimal">
+              <ol start="11" type="1">
               <li>To access advanced options, including excluding directories from the image, adding deployment scripts that execute when the image is launched or the status changes, or requiring the user to verify understanding of any license restrictions, click Advanced Options:</li>
               <li>To exclude files from the image, list each file to exclude on a separate line and then click Next. (This step is optional. To skip this step, just click Next.)</li>
               <li>To add a deployment script, click in the search field and search for the title of the script.</li>
@@ -98,13 +98,15 @@
               <ul>
               <li>To create a new deployment script:
               <ul>
-              <li>Click Create New Script, enter a title for the script, and then either click URL and enter the URL to the script, or click Full Text and enter the deployment script.</li>
+              <li>Click Create New Script, enter a title for the script, and then either click URL and enter the URL to the script, or click Full Text and enter the deployment script.
+              <ul>
               <li>URL Option: URLs must start with http[s]://</li>
               <li>Full Text Option: It is expected that your script will include a shebang line ex: #!/bin/bash</li>
+              </ul></li>
               <li>When done, click Create and Add, and then click Next. (Just click Next to continue to the next screen without adding a new script).</li>
               </ul></li>
               </ul>
-              <ol start="14" style="list-style-type: decimal">
+              <ol start="14" type="1">
               <li>To list any licensed software used in the image and require users to agree to the license agreement before launching, click in the search field and search for the license title.</li>
               </ol>
               <ul>
@@ -114,20 +116,20 @@
               <li>When done, click Create and Add, and then click Next. (Just click Next to continue to the next screen without adding a new script).</li>
               </ul></li>
               </ul>
-              <ol start="15" style="list-style-type: decimal">
+              <ol start="15" type="1">
               <li>In the Review screen, click the checkbox certifying that the license does not contain any license-restricted software.</li>
               <li>Click request image.</li>
               </ol>
-              <h1 id="viewing-your-machine-requests"><a href="#viewing-your-machine-requests">Viewing your Machine Requests</a></h1>
+              <h1 id="viewing-your-machine-requests">Viewing your Machine Requests</h1>
               <p>In the current UI, you can view your lists of images and image requests.</p>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li>In the Atmosphere current UI, click Images on the top menu bar.</li>
               <li>Click My Images tab at the top of the screen.</li>
               </ol>
               <p>This will take you through how to add members to your private machine request.</p>
-              <h1 id="making-your-application-private"><a href="#making-your-application-private">Making your application private</a></h1>
+              <h1 id="making-your-application-private">Making your application private</h1>
               <p>To make your application private, select ‘Private’ or ‘Select’ in the visibility section. [SCREENSHOT]</p>
-              <h1 id="adding-membership"><a href="#adding-membership">Adding Membership</a></h1>
+              <h1 id="adding-membership">Adding Membership</h1>
               <p>To add members to your application, start typing their username and select the user you would like to add to your image. [SCREENSHOT]</p>
               </article>
             </div> <!-- #main -->

--- a/dist/index.html
+++ b/dist/index.html
@@ -8,9 +8,9 @@
         <meta http-equiv="Content-Style-Type" content="text/css" />
         <meta name="generator" content="pandoc" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-                    <title></title>
+                    <title>00_welcome</title>
         <style type="text/css">code{white-space: pre;}</style>
-                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" type="text/css" />
+                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" />
                     <link rel="icon" href="themes/cyverse/media/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" href="themes/cyverse/media/css/normalize.min.css">
         <link rel="stylesheet" href="themes/cyverse/media/css/main.css">
@@ -43,9 +43,9 @@
                   </aside>
                               <!-- MAIN CONTENT -->
               <article>
-              <h1 id="atmosphere-guides"><a href="#atmosphere-guides">Atmosphere Guides</a></h1>
+              <h1 id="atmosphere-guides">Atmosphere Guides</h1>
               <p>This site hosts documentation for Atmosphere, the free, open-source cloud computing project (as distinct from CyVerse’s “cloud computing for scientists” service). It is intended for both “site operators” (groups interested in operating/supporting their own Atmosphere deployment), users (very incomplete), and developers who are interested in contributing to the project.</p>
-              <h2 id="for-site-operators"><a href="#for-site-operators">For Site Operators</a></h2>
+              <h2 id="for-site-operators">For Site Operators</h2>
               <ul>
               <li><a href="./install_guide.html">Install Guide</a></li>
               <li><a href="./connecting_cloud_provider.html">Connecting a Cloud Provider</a></li>
@@ -54,12 +54,13 @@
               <li><a href="./gateone_background.html">GateOne Background</a></li>
               <li><a href="./openstack_troubleshooting_guide.html">OpenStack Troubleshooting Guide</a></li>
               </ul>
-              <h2 id="for-users"><a href="#for-users">For Users</a></h2>
+              <h2 id="for-users">For Users</h2>
               <ul>
+              <li><a href="./getting_started.html">Getting Started</a></li>
               <li><a href="./user_guide.html">User Guide</a></li>
               <li><a href="./imaging_guide.html">Imaging Guide</a></li>
               </ul>
-              <h2 id="for-developers"><a href="#for-developers">For Developers</a></h2>
+              <h2 id="for-developers">For Developers</h2>
               <ul>
               <li><a href="./project_contribution_guide.html">Project Contribution Guide</a></li>
               <li><a href="./code_guidelines.html">Code Guidelines</a></li>

--- a/dist/install_guide.html
+++ b/dist/install_guide.html
@@ -8,9 +8,9 @@
         <meta http-equiv="Content-Style-Type" content="text/css" />
         <meta name="generator" content="pandoc" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-                    <title></title>
+                    <title>installation_guide</title>
         <style type="text/css">code{white-space: pre;}</style>
-                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" type="text/css" />
+                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" />
                     <link rel="icon" href="themes/cyverse/media/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" href="themes/cyverse/media/css/normalize.min.css">
         <link rel="stylesheet" href="themes/cyverse/media/css/main.css">
@@ -57,10 +57,10 @@
                   </aside>
                               <!-- MAIN CONTENT -->
               <article>
-              <h1 id="installation-of-atmosphere-and-troposphere"><a href="#installation-of-atmosphere-and-troposphere">Installation of Atmosphere and Troposphere</a></h1>
-              <h3 id="overview"><a href="#overview">Overview</a></h3>
+              <h1 id="installation-of-atmosphere-and-troposphere">Installation of Atmosphere and Troposphere</h1>
+              <h3 id="overview">Overview</h3>
               <p>The installation of Atmosphere and Troposphere can be a complex task when done manually. Fortunately, the team behind the stack has created a deployment tool that attempts to remove some of the frustrations that one could come across. <a href="https://github.com/iPlantCollaborativeOpenSource/clank">Clank</a> is a deployment tool that uses <a href="https://www.ansible.com/">ansible</a> technology. It deploys the Atmosphere and Troposphere infrastructure within a Linux environment (perferably Ubuntu) to make using OpenStack fo on-demanding computing needs easy.</p>
-              <h4 id="system-dependencies"><a href="#system-dependencies">System Dependencies</a></h4>
+              <h4 id="system-dependencies">System Dependencies</h4>
               <p>Clank perfoms a local install of Atmosphere and Troposphere, and as a result, a few dependencies are required to allow clank to properly run.</p>
               <p>The lines below allow clank to run its own series of commands to get ansible to run locally:</p>
               <pre><code>apt-get update
@@ -73,7 +73,7 @@
               pip install -r clank/clank_requirements.txt</code></pre>
               <p>If you perform a pip freeze, you should see new libraries added.</p>
               <pre><code>pip freeze</code></pre>
-              <h4 id="requirements-for-configuration"><a href="#requirements-for-configuration">Requirements for Configuration</a></h4>
+              <h4 id="requirements-for-configuration">Requirements for Configuration</h4>
               <p>A few files are required to be filled out in order for clank to properly function. You can find all the files below in the dist_files directory.</p>
               <ul>
               <li><p>variables.yml (See <a href="https://github.com/cyverse/clank/blob/master/dist_files/variables.yml.dist">variables dist</a> for blank template)</p></li>
@@ -90,23 +90,22 @@
               TODO:
               - Condense variables.yml.dist and explain the other vars needed by user (e.g. openstack, ldap, ELK, etc).
               -->
-              
-              <h4 id="installation"><a href="#installation">Installation</a></h4>
+              <h4 id="installation">Installation</h4>
               <p>Once you have the completed files, its time to run clank! Change directories into the clank repo.</p>
               <pre><code>cd clank</code></pre>
               <p>In order to override the default arguments for clank, we will need to pass in the variables.yml file we worked on previously.</p>
               <pre><code>VARIABLES_YML_FILE=/path/to/our/completed/variables.yml</code></pre>
               <p>And now we select the <code>playbooks/deploy_stack.yml</code> playbook to install the entire Atmosphere stack. Use –limit to define the target-host you wish to install atmosphere to.</p>
-              <h5 id="calling-ansible-playbook"><a href="#calling-ansible-playbook">Calling ansible-playbook</a></h5>
+              <h5 id="calling-ansible-playbook">Calling ansible-playbook</h5>
               <p>By default, Clank is configured to deploy against localhost. To deploy to a remote target, modify <a href="https://github.com/cyverse/clank/blob/master/hosts">the <code>hosts</code> file</a>, replacing the target-host: <code>localhost</code> to the correct Server/IP address.</p>
               <pre><code># Note the &#39;@&#39; required when calling ansible-playbook
               # playbooks/deploy_stack.yml will install the full Atmosphere Stack (Atmosphere, Troposphere, and atmosphere-ansible).
               ansible-playbook playbooks/deploy_stack.yml -e @$VARIABLES_YML_FILE</code></pre>
-              <h4 id="advanced-configuration"><a href="#advanced-configuration">Advanced Configuration</a></h4>
-              <h5 id="ssl-certs"><a href="#ssl-certs">SSL CERTS</a></h5>
-              <h6 id="installation-of-self-signed-ssl-certs"><a href="#installation-of-self-signed-ssl-certs">Installation of self-signed SSL certs</a></h6>
+              <h4 id="advanced-configuration">Advanced Configuration</h4>
+              <h5 id="ssl-certs">SSL CERTS</h5>
+              <h6 id="installation-of-self-signed-ssl-certs">Installation of self-signed SSL certs</h6>
               <p>By default, clank will install self-signed SSL certificates. While this is fine for evaluation, it is encouraged to use letsencrypt or bring your own SSL certificates when running the Atmosphere platform in a production setting.</p>
-              <h6 id="bringing-your-own-ssl-certs"><a href="#bringing-your-own-ssl-certs">Bringing your own SSL certs</a></h6>
+              <h6 id="bringing-your-own-ssl-certs">Bringing your own SSL certs</h6>
               <p>To have clank install your own ssl certs, rather than create the self signed certs, the following changes should be included in your variables.yml file:</p>
               <pre><code># SSL RELATED VARS
               CREATE_SSL: false                           # Set this to false if you wish to pass in your own certs
@@ -116,7 +115,7 @@
               TLS_BYO_PRIVKEY_SRC: /location/to/my/ssl/private/key/we/would/like/to/use/example.server.key         #Absolute Path Recommended
               TLS_BYO_CERT_SRC: /location/to/my/ssl/cert/we/would/like/to/use/example.server.crt                   #Absolute Path Recommended
               TLS_BYO_CACHAIN_SRC: /location/to/my/ssl/bundle_cert/we/would/like/to/use/example.server.cachain.crt #Absolute Path Recommended</code></pre>
-              <h6 id="using-letsencrypt-to-generate-ssl-certs"><a href="#using-letsencrypt-to-generate-ssl-certs">Using letsencrypt to generate SSL certs</a></h6>
+              <h6 id="using-letsencrypt-to-generate-ssl-certs">Using letsencrypt to generate SSL certs</h6>
               <p>To have clank run letsencrypt, rather than create self-signed certs, the following changes should be included in your variables.yml file:</p>
               <pre><code># NOTE: At least one valid email is requried for admin. If given, this user will be emailed when errors occur in Atmosphere, Troposphere, and for user contact/feedback.
               ADMINS_EMAIL_TUPLE: [[&#39;Atmosphere Admin&#39;, &#39;valid-email@required&#39;], [&#39;Admin Two&#39;, &#39;valid-email@required&#39;]]
@@ -126,49 +125,49 @@
               
               TLS_LETSENCRYPT_ENABLE: true
               TLS_LETSENCRYPT_EMAIL: &quot;{{ ADMINS_EMAIL_TUPLE[0][1] }}&quot;</code></pre>
-              <h5 id="ssh-keys"><a href="#ssh-keys">SSH Keys</a></h5>
+              <h5 id="ssh-keys">SSH Keys</h5>
               <p>You can have clank install your previously created ssh keys of choice, rather than create new ones. To do so, make the changes to your variables.yml file:</p>
               <pre><code># SSH KEYS
               CREATE_SSH_KEYS: false                     # Set this to false if you wish to pass in your own ssh keys     
               ID_RSA:  /location/to/my/id_rsa_key/my_key_id_rsa                      #Absolute Path Recommended
               ID_RSA_PUB: /location/to/my/id_rsa_public_key/my_key_id_rsa.pub        #Absolute Path Recommended</code></pre>
-              <h5 id="atmosphere-plugins"><a href="#atmosphere-plugins">Atmosphere Plugins</a></h5>
+              <h5 id="atmosphere-plugins">Atmosphere Plugins</h5>
               <p>The Atmosphere API has support for a few different types of plugins, that can be included or changed by changing the variables.yml file. Described below are the most commonly configured plugins, related to account and machine validation. For a full list, check the <a href="https://github.com/cyverse/atmosphere/blob/master/atmosphere/settings/local.py.j2">atmosphere settings dist file</a></p>
-              <h6 id="creating-a-new-plugin-for-atmosphere"><a href="#creating-a-new-plugin-for-atmosphere">Creating a new plugin for Atmosphere</a></h6>
+              <h6 id="creating-a-new-plugin-for-atmosphere">Creating a new plugin for Atmosphere</h6>
               <p>If you are interested in creating a new plugins for atmosphere: 1) Fork atmosphere 2) Create the file and Class name in question. Most plugins will have a specific method signature that is expected, be sure thats included. 3) To install that plugin with clank, you will need to point to <em>your repository and branch</em> when filling out the contents of the <code>variables.yml</code> file. 4) Follow the instructions below and include ‘your.plugin.path.ClassName’ instead of one from the list.</p>
-              <h6 id="account-validation-plugins"><a href="#account-validation-plugins">Account Validation Plugins</a></h6>
+              <h6 id="account-validation-plugins">Account Validation Plugins</h6>
               <p>Account validation plugins determine what users (after being authenticated by CAS/LDAP/Openstack/etc.) are authorized to use the Atmosphere platform. By default, the ‘AlwaysAllow’ plugin is used, ensuring that any user who is authenticated will be authorized to use atmosphere.</p>
               <p><strong>IMPORTANT NOTE</strong>:Account validation takes <em>a list of plugins</em>, <strong>ALL</strong> plugins will be tested for a given user. A user is only denied access when <strong>ALL</strong> Plugins fail for that user.</p>
               <p>Additional choices for the Account validation plugin are: - ‘atmosphere.plugins.auth.validation.LDAPGroupRequired’ # Require that the user has a valid LDAP group - ‘jetstream.plugins.auth.validation.XsedeProjectRequired’ # Require that the user has a valid XSede project in TAS external API To select a non-default account validation plugin, include this line in your variables.yml</p>
               <pre><code>VALIDATION_PLUGINS = [&#39;atmosphere.plugins.auth.validation.LDAPGroupRequired&#39;,]</code></pre>
-              <h6 id="machine-validation-plugin"><a href="#machine-validation-plugin">Machine Validation Plugin</a></h6>
+              <h6 id="machine-validation-plugin">Machine Validation Plugin</h6>
               <p>Machine validation plugins determine what cloud provider ‘machines’ will be included in the Atmosphere imaging catalog (and viewable by users of Atmosphere). By default, the ‘BasicValidation’ plugin is used, ensuring that any machine that is found by the Admin user of the cloud provider will be included in the atmosphere image catalog.</p>
               <p><strong>IMPORTANT NOTE</strong>: Machine validation takes <em>a single plugin</em>.</p>
               <p>Additional choices for the Machine validation plugin are: - “atmosphere.plugins.machine_validation.WhitelistValidation” # Accept images with specific metadata, (reject all other images) - “atmosphere.plugins.machine_validation.BlacklistValidation” # Reject images with specific metadata - “atmosphere.plugins.machine_validation.CyverseValidation” # Reject images with specific metadata &amp; require author to be admin user.</p>
               <p>To select a non-default machine validation plugin, include this line in your variables.yml</p>
               <pre><code>MACHINE_VALIDATION_PLUGIN = &quot;atmosphere.plugins.machine_validation.CyverseValidation&quot;</code></pre>
-              <h4 id="advanced-installation"><a href="#advanced-installation">Advanced Installation</a></h4>
+              <h4 id="advanced-installation">Advanced Installation</h4>
               <p>Because clank uses <code>ansible-playbook</code> directly, there are lots of ways to break up clank’s playbooks to deploy portions of the Atmosphere platform.</p>
-              <h5 id="tags"><a href="#tags">Tags</a></h5>
+              <h5 id="tags">Tags</h5>
               <p>You are able to isolate which portions of clank you want to run specifically. To do this you can pass in the tags flag to the <code>clank.py</code> script:</p>
               <pre><code># print-vars tag will print out ansible&#39;s interpretation of variables before making changes to the system
               ansible-playbook playbooks/deploy_stack.yml -e @/path/to/my/clank-variables.yml -vvvvv -e &quot;CLANK_VERBOSE=true&quot; --tags print-vars
               
               # atmosphere tag will install/update only the &#39;atmosphere&#39; portion of the Atmosphere platform.
               ansible-playbook playbooks/deploy_stack.yml -e @/path/to/my/clank-variables.yml --tags atmosphere</code></pre>
-              <h5 id="skip"><a href="#skip">Skip</a></h5>
+              <h5 id="skip">Skip</h5>
               <p>Inversely, you can skip sections of the installation by choosing tags to skip:</p>
               <pre><code># You can skip these tags to save time if you are rebuilding the Atmosphere platform.
               ansible-playbook playbooks/deploy_stack.yml -e @/path/to/my/clank-variables.yml --skip-tags &quot;clone-repo,data-load,npm,pip-install-requirements,apt-install&quot;
               
               # and you can skip these tags if you just want to install the &#39;atmosphere&#39; portion of the Atmosphere platform
               ansible-playbook playbooks/deploy_stack.yml -e @/path/to/my/clank-variables.yml --skip dependencies,troposphere # skips over the installation of dependencies and troposphere</code></pre>
-              <h2 id="what-to-do-after-installing-clank"><a href="#what-to-do-after-installing-clank">What to do after installing Clank</a></h2>
-              <h3 id="starting-the-atmosphere-service-and-logging-in"><a href="#starting-the-atmosphere-service-and-logging-in">Starting the Atmosphere service and logging in</a></h3>
+              <h2 id="what-to-do-after-installing-clank">What to do after installing Clank</h2>
+              <h3 id="starting-the-atmosphere-service-and-logging-in">Starting the Atmosphere service and logging in</h3>
               <p>After you have run clank.py successfully, you will need to run:</p>
               <pre><code>service atmosphere start</code></pre>
               <p>At which point you should be able to point your browser of choice to <code>https://&lt;your_server_url&gt;/</code>. Login (via Mock, CAS, or the AuthenticationBackend you are using) and you should see your username in the top-right corner. <img src="./media/troposphere_first_login.gif" alt="Troposphere first login" /></p>
-              <h3 id="setting-your-user-as-staff-and-superuser"><a href="#setting-your-user-as-staff-and-superuser">Setting your user as staff and superuser</a></h3>
+              <h3 id="setting-your-user-as-staff-and-superuser">Setting your user as staff and superuser</h3>
               <p>After you have logged in once, you will need to set your user as a staff/superuser.</p>
               <p>Because you have to be a superuser in order to access the /admin page for Atmosphere, you will have to do this by the Atmosphere Python REPL:</p>
               <pre><code># BASH:
@@ -181,27 +180,27 @@
               user.is_superuser = True
               user.is_staff = True
               user.save()</code></pre>
-              <h3 id="connecting-to-a-cloud-provider"><a href="#connecting-to-a-cloud-provider">Connecting to a Cloud Provider</a></h3>
+              <h3 id="connecting-to-a-cloud-provider">Connecting to a Cloud Provider</h3>
               <p>Now that you have logged in and marked your user an administrator, you are ready to connect to the cloud. See <a href="./connecting_cloud_provider.html">Connecting a Cloud Provider</a>.</p>
-              <h3 id="creating-accounts-using-troposphere"><a href="#creating-accounts-using-troposphere">Creating Accounts using Troposphere</a></h3>
+              <h3 id="creating-accounts-using-troposphere">Creating Accounts using Troposphere</h3>
               <p>To Add an account with Troposphere, select ‘Create New Account’ from the ‘admin’-&gt;‘Manage Accounts’ tabs in Troposphere. A modal should appear asking for some information about the user:</p>
-              <h4 id="describing-the-create-account-modal"><a href="#describing-the-create-account-modal">Describing the ‘Create Account’ modal:</a></h4>
+              <h4 id="describing-the-create-account-modal">Describing the ‘Create Account’ modal:</h4>
               <p>Atmosphere username - The <code>username</code> of the <code>core.AtmosphereUser</code> that will be retrieved/created and then assigned to the new identity. Atmosphere Group Name - The <code>name</code> of the <code>core.Group</code> that will be retrieved/created (connected to the Atmosphere Username) and then assigned (Membership roles) to the new identity. Provider - The Cloud Provider you wish to associate the new account with Quota - The quota you want assigned to your new openstack account (Uses Default Quota by default) Credentials - A list of key/value pairings that describe your user’s openstack account. For a new account Create a new account - If true, only <code>key</code> is required as a credential, password/tenant name will be generated and saved to the identity. If False, all three credentials (key, secret, ex_project_name) are required. Is this an admin account - If true, (create a new account should be False, here) the account is provisioned differently and then linked to the provider.</p>
               <p>Upon creation, Atmosphere will test the identity. If for any reason the identity does <em>not</em> produce a valid <code>rtwo.Driver</code> the identity will be deleted and an error message will be thrown.</p>
-              <h4 id="adding-the-admin-account-to-your-new-provider"><a href="#adding-the-admin-account-to-your-new-provider">Adding the admin account to your new provider</a></h4>
+              <h4 id="adding-the-admin-account-to-your-new-provider">Adding the admin account to your new provider</h4>
               <p>Before you can start adding accounts, you need to designate an identity as “the admin account” for the new provider. Doing this grants you access to create new accounts, manage users within openstack, as well as monitoring and imaging services through Atmosphere.</p>
               <p>After you create the account, you should see it appear in the list of “Identities” just below ‘Create New Account’ button in Troposphere.</p>
-              <div class="figure">
-              <img src="./media/troposphere_create_admin_account.png" alt="Troposphere admin account creation" /><p class="caption">Troposphere admin account creation</p>
-              </div>
-              <h4 id="adding-a-new-user-account-to-your-new-provider"><a href="#adding-a-new-user-account-to-your-new-provider">Adding a new user account to your new provider</a></h4>
+              <figure>
+              <img src="./media/troposphere_create_admin_account.png" alt="Troposphere admin account creation" /><figcaption>Troposphere admin account creation</figcaption>
+              </figure>
+              <h4 id="adding-a-new-user-account-to-your-new-provider">Adding a new user account to your new provider</h4>
               <p>Creating a new account is a simpler process, you can use the description above and the screenshot below to help answer the question of whats required.</p>
               <p>Account creation takes a few seconds more than admin account creation (to be sure all of our pieces are properly adjusted).</p>
               <p>Upon creation, Atmosphere will test this identity. If for any reason the identity does <em>not</em> produce a valid <code>rtwo.Driver</code> the identity will be deleted and an error message will be thrown.</p>
               <p>After account creation, you should see it appear in the list of “Identities” just below ‘Create New Account’ button in Troposphere.</p>
-              <div class="figure">
-              <img src="./media/troposphere_create_user_account.png" alt="Troposphere user account creation" /><p class="caption">Troposphere user account creation</p>
-              </div>
+              <figure>
+              <img src="./media/troposphere_create_user_account.png" alt="Troposphere user account creation" /><figcaption>Troposphere user account creation</figcaption>
+              </figure>
               </article>
             </div> <!-- #main -->
         </div> <!-- #main-container -->

--- a/dist/openstack_troubleshooting_guide.html
+++ b/dist/openstack_troubleshooting_guide.html
@@ -8,9 +8,9 @@
         <meta http-equiv="Content-Style-Type" content="text/css" />
         <meta name="generator" content="pandoc" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-                    <title></title>
+                    <title>openstack_troubleshooting_guide</title>
         <style type="text/css">code{white-space: pre;}</style>
-                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" type="text/css" />
+                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" />
                     <link rel="icon" href="themes/cyverse/media/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" href="themes/cyverse/media/css/normalize.min.css">
         <link rel="stylesheet" href="themes/cyverse/media/css/main.css">
@@ -49,13 +49,13 @@
                   </aside>
                               <!-- MAIN CONTENT -->
               <article>
-              <h1 id="openstack-troubleshooting-guide"><a href="#openstack-troubleshooting-guide">OpenStack Troubleshooting Guide</a></h1>
+              <h1 id="openstack-troubleshooting-guide">OpenStack Troubleshooting Guide</h1>
               <p>This is a collection of OpenStack troubleshooting tips. These are not Atmosphere(1)-specific but may still be useful to operators.</p>
-              <h2 id="instance-troubleshooting"><a href="#instance-troubleshooting">Instance Troubleshooting</a></h2>
-              <h3 id="launch-instance-on-specific-compute-host"><a href="#launch-instance-on-specific-compute-host">Launch Instance on Specific Compute Host</a></h3>
+              <h2 id="instance-troubleshooting">Instance Troubleshooting</h2>
+              <h3 id="launch-instance-on-specific-compute-host">Launch Instance on Specific Compute Host</h3>
               <p>You may want to launch an instance on a specific compute host in order to troubleshoot an issue, or change the configuration of nova-compute service on one compute host, and test it.</p>
-              <p>See this doc from the OpenStack Administrator Guide: <a href="https://docs.openstack.org/admin-guide/cli-nova-specify-host.html">https://docs.openstack.org/admin-guide/cli-nova-specify-host.html</a></p>
-              <h3 id="connect-to-instance-console-using-desktop-spice-client"><a href="#connect-to-instance-console-using-desktop-spice-client">Connect to Instance Console Using Desktop SPICE client</a></h3>
+              <p>See this doc from the OpenStack Administrator Guide: <a href="https://docs.openstack.org/admin-guide/cli-nova-specify-host.html" class="uri">https://docs.openstack.org/admin-guide/cli-nova-specify-host.html</a></p>
+              <h3 id="connect-to-instance-console-using-desktop-spice-client">Connect to Instance Console Using Desktop SPICE client</h3>
               <p>You may want to do this if the SPICE HTML5 client in Horizon is not responding to keyboard input, not refreshing the display, or throwing errors in the text box underneath the video console (e.g. <a href="https://forum.opennebula.org/t/4-11-spice-is-not-refreshing/336">this behavior</a>). Instead, you can use a GTK client which may not exhibit these bugs.</p>
               <p>First, determine the compute host your instance is running on – Horizon shows you this, or ask the OpenStack CLI <code>openstack server-show my-instance-uuid</code>.</p>
               <p>Then, SSH to that compute host and look for listening SPICE ports (typically 5900+). Each will be associated with a qemu process. Look for the process containing a <code>-uuid</code> argument that matches your instance ID, and read its <code>-spice</code> argument – here it is <code>port=5900,addr=172.29.236.147</code>. (I have snipped the very long argument list.)</p>
@@ -70,29 +70,43 @@
               <p>Here we are using an OpenStack cloud deployed using OpenStack-Ansible, so the process is only listening on the internal management network. We can access this network by creating an SSH connection to the compute host with port forwarding configured:</p>
               <p><code>ssh -p 1657 -L 5901:172.29.236.147:5900 root@marana-17.cyverse.org</code></p>
               <p>These instructions were tested using the <code>spicy</code> client included with the <code>spice-client-gtk</code> APT package. With SSH port forwarding, you can point your local SPICE client to localhost on port 5901; the connection will be forwarded to 172.29.236.147:5900 on the compute host. A graphical console session should be obtained which accepts keyboard input, ctrl+alt+del, etc.</p>
-              <h3 id="inspect-the-filesystem-of-a-running-instance-with-broken-networking"><a href="#inspect-the-filesystem-of-a-running-instance-with-broken-networking">Inspect the Filesystem of a Running Instance with Broken Networking</a></h3>
+              <h3 id="inspect-the-filesystem-of-a-running-instance-with-broken-networking">Inspect the Filesystem of a Running Instance with Broken Networking</h3>
               <p>To inspect filesystem of an instance that will not accept SSH connections or a console session, you can create a snapshot (image) of that instance, convert that image to a volume, and then attach that volume to another instance.</p>
               <ul>
               <li>Create a snapshot of instance using OpenStack CLI or Horizon UI
               <ul>
               <li>In OpenStack CLI: <code>openstack server image create myInstance --name myInstanceSnapshot</code></li>
               </ul></li>
-              <li><p>Convert snapshot (image) to volume in OpenStack CLI (<a href="https://docs.openstack.org/user-guide/common/cli-manage-volumes.html">reference</a>) <code># Choose an image by its UUID   openstack image list   # Note image size for later   openstack image show deadbeef-dead-dead-dead-beefbeefbeef   # Choose an availability zone   openstack availability zone list   # Create volume, size in GB must be at least as large as the image virtual size (see note below with a *)   openstack volume create --image deadbeef-dead-dead-dead-beefbeefbeef --size 10 --availability-zone nova my-new-volume   # Wait for volume to be created, check status with this command   openstack volume show beefdead-beef-beef-beef-deaddeaddead</code></p></li>
-              <li><p>Attach volume to another working, running instance <code>openstack server add volume myInstance beefdead-beef-beef-beef-deaddeaddead --device /dev/vdc</code> (Ensure that /dev/vdc is not used, increment if necessary)</p></li>
-              <li><p>SSH to the working instance and mount the filesystem <code>mkdir broken-instance   mount /dev/vdc1 broken-instance</code></p></li>
+              <li><p>Convert snapshot (image) to volume in OpenStack CLI (<a href="https://docs.openstack.org/user-guide/common/cli-manage-volumes.html">reference</a>)</p>
+              <pre><code># Choose an image by its UUID
+              openstack image list
+              # Note image size for later
+              openstack image show deadbeef-dead-dead-dead-beefbeefbeef
+              # Choose an availability zone
+              openstack availability zone list
+              # Create volume, size in GB must be at least as large as the image virtual size (see note below with a *)
+              openstack volume create --image deadbeef-dead-dead-dead-beefbeefbeef --size 10 --availability-zone nova my-new-volume
+              # Wait for volume to be created, check status with this command
+              openstack volume show beefdead-beef-beef-beef-deaddeaddead</code></pre></li>
+              <li><p>Attach volume to another working, running instance</p>
+              <pre><code>openstack server add volume myInstance beefdead-beef-beef-beef-deaddeaddead --device /dev/vdc</code></pre>
+              <p>(Ensure that /dev/vdc is not used, increment if necessary)</p></li>
+              <li><p>SSH to the working instance and mount the filesystem</p>
+              <pre><code>mkdir broken-instance
+              mount /dev/vdc1 broken-instance</code></pre></li>
               </ul>
               <p>Now you can inspect the filesystem, look at the logs, find out what’s gone wrong</p>
               <p><code>*</code> Volume creation may fail and you see in cinder-volume.log (perhaps on your cinder storage server(s)):</p>
               <pre><code>ImageUnacceptable: Image 0a23ea76-d661-4483-a562-cba0a3f58a21 is unacceptable: Image virtual size is 20GB and doesn&#39;t fit in a volume of size 10GB.</code></pre>
               <p>https://bugs.launchpad.net/cinder/+bug/1599147 This is fixed but not yet in current stable releases of OpenStack (as of April 2017). Until then, you must look for this error and then specify a larger size when running <code>openstack volume create</code>.</p>
-              <h2 id="image-troubleshooting"><a href="#image-troubleshooting">Image Troubleshooting</a></h2>
-              <h3 id="increase-the-size-of-a-base-cloud-image"><a href="#increase-the-size-of-a-base-cloud-image">Increase the size of a base cloud image</a></h3>
+              <h2 id="image-troubleshooting">Image Troubleshooting</h2>
+              <h3 id="increase-the-size-of-a-base-cloud-image">Increase the size of a base cloud image</h3>
               <p>If your flavors/sizes in OpenStack do not have root disks, then you may find yourself restricted by the size of cloud image stored in Glance. If you try to install a GUI or other large software packages then you may quickly run out of disk space.</p>
               <p>qcow2 image files (possibly also raw image files) can be resized before they are uploaded to glance using the <code>qemu-img</code> command-line tool:</p>
               <p><code>qemu-img resize xenial-server-cloudimg-amd64-disk1.img +5GB</code></p>
               <p>This will result in more space available on the root filesystem of instances launched from the image.</p>
               <p>(When you increase the size of a compressed qcow2 image using <code>qemu-img resize</code>, it may not actually increase the size of the compressed image file.)</p>
-              <h3 id="cannot-re-use-glance-image-uuid-purge-it-from-database"><a href="#cannot-re-use-glance-image-uuid-purge-it-from-database">Cannot re-use Glance image UUID? Purge it from Database</a></h3>
+              <h3 id="cannot-re-use-glance-image-uuid-purge-it-from-database">Cannot re-use Glance image UUID? Purge it from Database</h3>
               <p>atmosphere(1) explicitly sets UUIDs for Glance images, as some deployers wish to maintain consistent matching UUIDs for the same image across multiple OpenStack providers. At some point you may wish to delete a Glance image and re-create it (perhaps so you can upload different image data).</p>
               <p>This exposes an issue with Glance: the record of a Glance image (<em>including its UUID</em>) persists in the Glance database after the image is deleted, and Glance will not allow you to create a new image with the same UUID as an existing record. (Incidentally, this behavior is <a href="https://bugs.launchpad.net/glance/+bug/1176978">intended</a> by the Glance developers.)</p>
               <pre><code>MariaDB [glance]&gt; select id, name, status from images where id = &#39;948cf114-dfd7-4e2d-b84f-9bf6dab47aa3&#39;;

--- a/dist/project_contribution_guide.html
+++ b/dist/project_contribution_guide.html
@@ -8,9 +8,9 @@
         <meta http-equiv="Content-Style-Type" content="text/css" />
         <meta name="generator" content="pandoc" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-                    <title></title>
+                    <title>project_contribution_guide</title>
         <style type="text/css">code{white-space: pre;}</style>
-                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" type="text/css" />
+                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" />
                     <link rel="icon" href="themes/cyverse/media/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" href="themes/cyverse/media/css/normalize.min.css">
         <link rel="stylesheet" href="themes/cyverse/media/css/main.css">
@@ -103,10 +103,10 @@
                   </aside>
                               <!-- MAIN CONTENT -->
               <article>
-              <h1 id="atmosphere-project-contribution-guide"><a href="#atmosphere-project-contribution-guide">Atmosphere Project Contribution Guide</a></h1>
+              <h1 id="atmosphere-project-contribution-guide">Atmosphere Project Contribution Guide</h1>
               <p>This guide is intended to orient community members who are interested in contributing to Atmosphere – learn about our development process, our technology stack, and our release strategy. Welcome to the project!</p>
               <p>This page has a couple of broken links, having recently been migrated from an internal wiki – they will be fixed soon once the linked content is migrated to atmosphere-guides.</p>
-              <h2 id="what-is-atmosphere"><a href="#what-is-atmosphere">What is Atmosphere?</a></h2>
+              <h2 id="what-is-atmosphere">What is Atmosphere?</h2>
               <p>Atmosphere or ‘atmo’ can refer to several different things:</p>
               <ul>
               <li><a href="https://atmo.cyverse.org/application">Atmosphere</a>(0), CyVerse’s “cloud computing for scientists” service</li>
@@ -114,87 +114,87 @@
               <li><a href="https://github.com/iPlantCollaborativeOpenSource/atmosphere">Atmosphere</a>(2), the API and back-end component of the above software project</li>
               </ul>
               <p>For clarity, this page will disambiguate all uses of “Atmosphere”.</p>
-              <h2 id="what-are-the-steps-to-contributing-to-atmospherecore-services"><a href="#what-are-the-steps-to-contributing-to-atmospherecore-services">What are the steps to contributing to Atmosphere/Core services?</a></h2>
+              <h2 id="what-are-the-steps-to-contributing-to-atmospherecore-services">What are the steps to contributing to Atmosphere/Core services?</h2>
               <p>Contribution to core-services products (usually) takes place in two different environments:</p>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li><a href="https://pods.iplantcollaborative.org/jira/secure/Dashboard.jspa">JIRA</a> - This is an external service where we document bugs, issues, and new features to be fixed.</li>
               <li><a href="https://github.com/cyverse/">Github</a> - This is where our codebase generally resides. See <a href="#where-is-the-code">Where is the code</a> for more details.</li>
               </ol>
-              <h3 id="the-atmosphere-workflow-for-jira-tickets"><a href="#the-atmosphere-workflow-for-jira-tickets">The Atmosphere workflow for JIRA tickets</a></h3>
-              <ol style="list-style-type: decimal">
+              <h3 id="the-atmosphere-workflow-for-jira-tickets">The Atmosphere workflow for JIRA tickets</h3>
+              <ol type="1">
               <li>Issues/Bugs/New Features that are found in the wild, during requirements gathering, etc. should be created as “JIRA Tickets” and assigned a <strong>fixVersion</strong> of <strong>Release Backlog</strong> or <strong>Product Backlog</strong>.
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li><strong>JIRA </strong>Operations<strong>-note:</strong> At this time the form only lets you set <strong>affectedVersion</strong>, which is not quite the same. We should make this easier for specific users (if the workflow allows for it)</li>
               </ol></li>
               <li><strong>JIRA Sprints and the Agile Board</strong>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li><strong>Tickets are assigned</strong> to match with the <strong>Release</strong> and <strong>Sprint </strong>Schedule:</li>
               <li>Currently, core-services is on a <strong>5 week</strong> release schedule. There are <strong>two 2-week sprints</strong> and a <strong>1-week sprint</strong> <strong>to prepare for and release</strong> the branch to the production servers.</li>
               <li>JIRA Tickets for both 2-week sprints are regularly assigned at the beginning of each release.
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li>During the first sprint after a release, primarily ‘Bug’ tickets will be assigned. This is done to give time for the changes to “settle” on the beta server for a few weeks.</li>
               <li>During the second sprint, primarily “Improvements and new feature” tickets will be assigned.</li>
               </ol></li>
               <li>The third sprint, only one week long, will be split between preparing for deployment and finishing up any lingering tickets that extend past the sprint deadline.</li>
               </ol></li>
               <li><strong>The Lifecycle of a ticket</strong>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li><strong>Starting work on a ticket</strong>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li>(If applicable) Tickets will move to <code>**Start Design**</code> and work with the design pipeline to gather requirements (See The Design Pipeline section for more details)</li>
               <li>Put the ticket into “<strong>Start Progress</strong>” and start writing Code to fix the bug/create the feature. </li>
               <li>Tests are written for any new bug to verify the failure has been fixed and for any new feature to help with QA. (See the Testing the Code section for more details)</li>
               <li>Documentation is written (See the Documenting the Code section for more details)</li>
               </ol></li>
               <li><strong>Reviewing a ticket</strong>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li>Ensure that the checklist for your PR template is complete before requesting review. (see below for more details)</li>
               <li>Put the ticket into “<strong>Review</strong>” step and assign to a project lead. (See Reviewing Code section for more details)</li>
               <li>Upon merge, a project lead will move the ticket to <strong>Resolved</strong> and assigned to QA for final approval/confirmation. Notes should be included that point to the new tests/documentation as appropriate.</li>
               </ol></li>
               </ol></li>
               </ol>
-              <h3 id="using-github-to-work-on-an-issuebugfeature"><a href="#using-github-to-work-on-an-issuebugfeature">Using github to work on an issue/bug/feature</a></h3>
-              <ol style="list-style-type: decimal">
+              <h3 id="using-github-to-work-on-an-issuebugfeature">Using github to work on an issue/bug/feature</h3>
+              <ol type="1">
               <li><strong>Fork the repo you intend to work on</strong>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li>If this is your first time contributing to a core-services repository, you will want to create a new fork.<span style="color: rgb(34,34,34);"> </span>Forking a repository<span style="color: rgb(34,34,34);"> allows you to freely experiment with changes without affecting the original project.</span></li>
               <li><span style="color: rgb(34,34,34);">Github’s documentation for working with forks is <a href="https://help.github.com/articles/fork-a-repo/">available here</a>.</span></li>
               </ol></li>
               <li><strong><span style="color: rgb(34,34,34);">Creating a feature branch</span></strong>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li>Before starting work on a new feature or bugfix, you should create a new branch. Creating branches for your work allows you to isolate your changes when they are ready for others to review. It also gives you the ability to change to another branch, to work on separate fixes or features as necessary.</li>
               </ol></li>
               <li><strong>Submitting a Pull Request</strong>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li>It’s a good idea to make pull requests early on. A pull request represents the start of a discussion, and doesn’t necessarily need to be the final, finished submission.</li>
               <li>It’s also useful to remember that if you have an outstanding pull request then pushing new commits to your GitHub repo will also automatically update the pull requests.</li>
               <li><strong>Specific to Core-services:</strong> Pull requests will be reviewed <strong>after</strong> the “Check list” in the Pull Request template has been completed, this should include new tests and documentation!</li>
               <li>GitHub’s documentation for working on pull requests is <a href="https://help.github.com/articles/using-pull-requests">available here</a>.</li>
               </ol></li>
               </ol>
-              <h4 id="pull-request-templates"><a href="#pull-request-templates">Pull Request Templates</a></h4>
+              <h4 id="pull-request-templates">Pull Request Templates</h4>
               <p>The pull request template used by core-services can be found on the github of Atmosphere or Troposphere in .<strong>/PULL_REQUEST_TEMPLATE</strong></p>
               <blockquote>
               <p><span style="color: rgb(255,0,0);"><strong>NOTE:</strong> Proposals for those PR templates can be found here, and can be updated prior to merge: <a href="https://github.com/cyverse/troposphere/pull/536"><span style="color: rgb(255,0,0);">https://github.com/cyverse/troposphere/pull/536</span></a> and <a href="https://github.com/cyverse/atmosphere/pull/250"><span style="color: rgb(255,0,0);">https://github.com/cyverse/atmosphere/pull/250</span></a></span></p>
               </blockquote>
-              <p>See this article for including a pull request template in your repository: <a href="https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/">https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/</a></p>
-              <h2 id="where-is-atmosphere-deployed"><a href="#where-is-atmosphere-deployed">Where is Atmosphere Deployed?</a></h2>
+              <p>See this article for including a pull request template in your repository: <a href="https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/" class="uri">https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/</a></p>
+              <h2 id="where-is-atmosphere-deployed">Where is Atmosphere Deployed?</h2>
               <p>Atmosphere(1) is deployed at CyVerse as Atmosphere(0), but also at several other organizations known by different names:</p>
               <ul>
               <li><a href="http://jetstream-cloud.org/">Jetstream Cloud</a> (partnership of Indiana University, TACC, &amp; CyVerse - Jetstream GitHub Organization: <a href="https://github.com/jetstream-cloud">jetstream-cloud</a>)</li>
               <li>MOC (Massechusetts Open Cloud) (Jonathan Bell: <a href="https://github.com/lokI8">github-profile</a>, Lucas H. Xu: <a href="https://github.com/xuhang57">github-profile</a>)</li>
               <li>Duke University / Duke Center for Genomic &amp; Computational Biology (<a href="https://github.com/Duke-GCB">Duke GCB</a>) (Darren Boss: <a href="https://genome.duke.edu/directory/gcb-staff/darren-boss">gcb-profile</a>; <a href="https://github.com/netscruff">github-profile</a>)</li>
               </ul>
-              <h2 id="resources-and-docs-for-new-contributors"><a href="#resources-and-docs-for-new-contributors">Resources and Docs for New Contributors</a></h2>
+              <h2 id="resources-and-docs-for-new-contributors">Resources and Docs for New Contributors</h2>
               <p>Familiarize yourself with the following links and use them as a reference. (Also check out the other guides on this site!)</p>
               <ul>
               <li><a href="./code_guidelines.html">Atmosphere Code Guidelines</a></li>
               <li><a href="./troubleshooting_guide.html">Atmosphere Troubleshooting Guide</a></li>
               <li><a href="http://docs.atmospherev2.apiary.io/">Atmosphere(2) API docs on Apiary</a></li>
               </ul>
-              <h2 id="where-is-the-code"><a href="#where-is-the-code">Where is the Code?</a></h2>
-              <h3 id="repositories-on-github"><a href="#repositories-on-github">Repositories on Github</a></h3>
+              <h2 id="where-is-the-code">Where is the Code?</h2>
+              <h3 id="repositories-on-github">Repositories on Github</h3>
               <p>(Should we make this a table of repo + link + purpose?)</p>
               <ul>
               <li><a href="https://github.com/iplantcollaborativeopensource/atmosphere">atmosphere</a>(2), and supporting projects:
@@ -218,7 +218,7 @@
               <li><a href="https://github.com/cyverse/atmosphere-guides">ansible-gateone-server</a></li>
               <li><a href="https://github.com/cyverse/atmosphere-guides">atmosphere-guides</a> documentation for Atmosphere(1)</li>
               </ul>
-              <h2 id="key-terms"><a href="#key-terms">Key Terms</a></h2>
+              <h2 id="key-terms">Key Terms</h2>
               <p>You’ll hear these a lot on the Atmosphere project:</p>
               <ul>
               <li><em>Instance</em>: a Virtual Machine (VM) or “cloud computer” running on Atmosphere(0) / OpenStack.</li>
@@ -227,12 +227,12 @@
               <li><em>Allocation Unit</em> <em>(AU)</em>: “roughly equivalent to using one CPU-hour, or to using one CPU core for one hour.” (<a href="https://pods.iplantcollaborative.org/wiki/display/atmman/Requesting+More+Atmosphere+Resources">source</a>)</li>
               <li><em>Modal</em>: a <a href="https://en.wikipedia.org/wiki/Modal_window">modal window</a> in a GUI; the Troposphere UI uses these extensively.</li>
               </ul>
-              <h2 id="technology-stack-overview"><a href="#technology-stack-overview">Technology Stack Overview</a></h2>
+              <h2 id="technology-stack-overview">Technology Stack Overview</h2>
               <p>This is intended to be an orientation to the main components of Atmosphere(1), their purpose, and their supporting technologies.</p>
-              <h3 id="atmosphere1"><a href="#atmosphere1">Atmosphere(1)</a></h3>
+              <h3 id="atmosphere1">Atmosphere(1)</h3>
               <p>Atmosphere(1), broadly, is a web application which supports user-friendly access to (and management of) cloud computing resources, such as virtual machines (servers/workstations) and storage volumes.</p>
               <p>Atmosphere(1) has a “micro-services” architecture in that the back-end API is separated from the front-end UI, but all deployments to date contain all components on one operating system environment (server).</p>
-              <h4 id="atmosphere2-api-and-back-end"><a href="#atmosphere2-api-and-back-end">Atmosphere(2) API and Back-End</a></h4>
+              <h4 id="atmosphere2-api-and-back-end">Atmosphere(2) API and Back-End</h4>
               <p>The API is written in Python using the <a href="https://www.djangoproject.com/">Django</a> web framework, backed by a <a href="https://en.wikipedia.org/wiki/PostgreSQL">PostgreSQL</a> database. As is typical for Django applications, Atmosphere(2) interacts with its database using Django’s <a href="https://en.wikipedia.org/wiki/Object-relational_mapping">object-relational mapper</a>.</p>
               <p>Things that Atmosphere(2) does:</p>
               <ul>
@@ -242,43 +242,43 @@
               <li>Keeps track of user <a href="http://www.cyverse.org/service-level-agreement#AtmoAllo">allocations</a></li>
               </ul>
               <p>The API is <a href="http://docs.atmospherev2.apiary.io/#reference">apparently documented here</a>.</p>
-              <h4 id="troposphere-ui"><a href="#troposphere-ui">Troposphere UI</a></h4>
+              <h4 id="troposphere-ui">Troposphere UI</h4>
               <p><a href="/wiki/display/csmgmt/Troposphere">Troposphere</a> is a separate front-end for Atmosphere(1), consisting of a Django application and JavaScript “single-page application” built with the <a href="https://facebook.github.io/react/">React</a> front-end framework. Troposphere can be thought of as a JavaScript client which interacts with Atmosphere(2) via RESTful API.</p>
-              <h4 id="web-server"><a href="#web-server">Web Server</a></h4>
+              <h4 id="web-server">Web Server</h4>
               <p>Both Atmosphere(2) and Troposphere are served by Nginx, which serves static assets directly and reverse proxies to uWSGI (etc.) for dynamically generated content.</p>
-              <h4 id="atmosphere-ansible"><a href="#atmosphere-ansible">atmosphere-ansible</a></h4>
+              <h4 id="atmosphere-ansible">atmosphere-ansible</h4>
               <p>atmosphere-ansible is the set of Ansible code that runs on newly provisioned cloud instances as part of the deployment process.</p>
-              <h5 id="subspace"><a href="#subspace">Subspace</a></h5>
+              <h5 id="subspace">Subspace</h5>
               <p><a href="https://github.com/iPlantCollaborativeOpenSource/subspace">Subspace</a> is a Python project that programmatically runs Ansible playbooks; Atmosphere(2) uses it to run atmosphere-ansible.</p>
-              <h3 id="clank"><a href="#clank">Clank</a></h3>
+              <h3 id="clank">Clank</h3>
               <p><a href="https://github.com/iPlantCollaborativeOpenSource/clank">Clank</a> is the set of automations that deploy Atmosphere(1) and most of its components.</p>
               <p>Clank wraps the deployment process using Ansible, but significant parts are still automated with a mix of bash scripting, makefile, and a custom Python “configure” script which generates application configuration from jinja2 templates and .ini files. Also, unlike other Ansible code that you may have seen, Clank must be run locally on the destination server, not from a remote deployment host. The future direction is to refactor this into idiomatic Ansible and remove some layers of indirection.</p>
-              <h3 id="monitoring-and-management"><a href="#monitoring-and-management">Monitoring and Management</a></h3>
+              <h3 id="monitoring-and-management">Monitoring and Management</h3>
               <p>These are optional integrations which are implemented for Atmosphere(0). They are not necessary for a successful Atmosphere(1) deployment.</p>
-              <h4 id="elk"><a href="#elk">ELK</a></h4>
+              <h4 id="elk">ELK</h4>
               <p><a href="http://logz.io/learn/complete-guide-elk-stack/">ELK stack</a> (Elasticsearch, Logstash, Kibana) handles logging information from Atmosphere-Ansible.</p>
-              <h4 id="new-relic"><a href="#new-relic">New Relic</a></h4>
-              <h4 id="sentry"><a href="#sentry">Sentry</a></h4>
+              <h4 id="new-relic">New Relic</h4>
+              <h4 id="sentry">Sentry</h4>
               <p>???</p>
-              <h3 id="openstack"><a href="#openstack">OpenStack</a></h3>
+              <h3 id="openstack">OpenStack</h3>
               <p>Atmosphere(1) is intended to be agnostic of cloud provider type, but all current deployments use OpenStack as the cloud provider back-end. OpenStack is a collection of projects which, together, provide infrastructure-as-a-service or a ‘cloud’.</p>
-              <h3 id="remote-access-methods"><a href="#remote-access-methods">Remote Access Methods</a></h3>
+              <h3 id="remote-access-methods">Remote Access Methods</h3>
               <p>Atmosphere(1) supports several means of users accessing their instances.</p>
-              <h4 id="ssh"><a href="#ssh">SSH</a></h4>
+              <h4 id="ssh">SSH</h4>
               <p>Users can create a secure shell to their VMs directly over the internet, authenticating either with their Atmosphere(0) credentials or with an SSH keypair. Atmosphere(1) is essentially uninvolved in this workflow, though it provides a way for users to automatically install their public SSH key on new and re-deployed instances.</p>
-              <h4 id="web-shell"><a href="#web-shell">Web Shell</a></h4>
+              <h4 id="web-shell">Web Shell</h4>
               <p>Web Shell gets you a command line session in your browser, launched from the Troposphere UI. Web Shell uses <a href="https://liftoff.github.io/GateOne/About/index.html">Gate One</a>, a web-based terminal emulator. The Gate One server creates an SSH connection to the instance and exposes that shell to the user in a web interface, proxying the SSH traffic. For Atmosphere(0), the GateOne server is known as “bob” / “atmo-proxy”.</p>
               <p>See <a href="./gateone_background.html">GateOne Background</a> for detailed design and troubleshooting information.</p>
-              <h4 id="web-desktop"><a href="#web-desktop">Web Desktop</a></h4>
+              <h4 id="web-desktop">Web Desktop</h4>
               <p>Web Desktop gets you a graphical desktop session in your browser, launched from the Troposphere UI. Web Desktop uses <a href="https://kanaka.github.io/noVNC">NoVNC</a>, a web-based VNC client. This is brokered through webaccess.cyverse.org.</p>
-              <p><a href="https://github.com/cyverse/nginx_novnc_auth">https://github.com/cyverse/nginx_novnc_auth</a></p>
-              <p><a href="https://github.com/cyverse/clank/blob/master/playbooks/utils/install_novnc_auth.yml">https://github.com/cyverse/clank/blob/master/playbooks/utils/install_novnc_auth.yml</a></p>
-              <h4 id="future-guacamole"><a href="#future-guacamole">Future: Guacamole</a></h4>
+              <p><a href="https://github.com/cyverse/nginx_novnc_auth" class="uri">https://github.com/cyverse/nginx_novnc_auth</a></p>
+              <p><a href="https://github.com/cyverse/clank/blob/master/playbooks/utils/install_novnc_auth.yml" class="uri">https://github.com/cyverse/clank/blob/master/playbooks/utils/install_novnc_auth.yml</a></p>
+              <h4 id="future-guacamole">Future: Guacamole</h4>
               <p><a href="http://guacamole.incubator.apache.org/">Guacamole</a> is an HTML5 remote desktop gateway which provides both a command-line shell and a graphical desktop. Guacamole is planned as a replacement for Gate One and NoVNC, though this is not implemented in production yet.</p>
-              <h2 id="clouds"><a href="#clouds">Clouds</a></h2>
+              <h2 id="clouds">Clouds</h2>
               <p>Atmosphere(0, 1, 2) provisions virtual machines on several ‘clouds’ which actually host the instances and computing infrastructure. Currently, all cloud providers use OpenStack. It is also possible for Atmosphere to provide access to commodity IaaS like Amazon Web Services (AWS), though this is not currently configured.</p>
-              <h2 id="tools-and-workflows"><a href="#tools-and-workflows">Tools and Workflows</a></h2>
-              <h3 id="common-technologies-and-tools"><a href="#common-technologies-and-tools">Common Technologies and Tools</a></h3>
+              <h2 id="tools-and-workflows">Tools and Workflows</h2>
+              <h3 id="common-technologies-and-tools">Common Technologies and Tools</h3>
               <p>No matter your sub-specialty, you’ll work with most/all of these as a member of the Atmosphere Team.</p>
               <ul>
               <li>Python programming language, used for Atmosphere(2), Ansible, Subspace</li>
@@ -288,16 +288,16 @@
               <li>SSH, used for remotely accessing servers</li>
               <li>git and Github, used for source control</li>
               </ul>
-              <h3 id="local-development-environment"><a href="#local-development-environment">Local Development Environment</a></h3>
+              <h3 id="local-development-environment">Local Development Environment</h3>
               <p>The local development environment-in-a-box is not yet published for community consumption. Coming soon!</p>
-              <h3 id="issue-tracking-systems"><a href="#issue-tracking-systems">Issue Tracking Systems</a></h3>
+              <h3 id="issue-tracking-systems">Issue Tracking Systems</h3>
               <p>The Atmosphere(0) team uses several internal systems to track development cycles and support issues. Unfortunately these are not accessible to community members. For now, please use the repository-specific Issues section in the appropriate GitHub repository (perhaps <a href="https://github.com/cyverse/atmosphere">atmosphere</a>(2)) to report an issue with Atmosphere(1,2).</p>
               <p>If you are an Atmosphere(0) <em>user</em> seeking assistance and you ended up here for some reason, please log into <a href="https://atmo.cyverse.org/">Atmosphere</a> and click the “Feedback &amp; Support” link at the bottom of the page, or email support at cyverse dot org.</p>
-              <h3 id="contributing-code"><a href="#contributing-code">Contributing Code</a></h3>
+              <h3 id="contributing-code">Contributing Code</h3>
               <p>Note that the following information may change soon as the Atmosphere(0) team refines the development process for Atmosphere(1).</p>
-              <h4 id="on-github"><a href="#on-github">On Github</a></h4>
+              <h4 id="on-github">On Github</h4>
               <p>Most of Atmosphere(1)’s code lives on GitHub. Contributions to these codebases should follow a fork-and-pull-request workflow.</p>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li>Create your own fork of the repository, work on the code there, test it in your local development environment</li>
               <li>Create a pull request</li>
               <li>Have someone else review and merge your pull request; ideally two people will review it.</li>
@@ -308,16 +308,16 @@
               <li><a href="https://github.com/iPlantCollaborativeOpenSource/troposphere">Troposphere</a>: <a href="https://github.com/lenards">Andrew Lenards</a></li>
               </ul>
               <p>Ancillary projects have a wider set of individuals with write access, these are typically members of the Atmosphere(0) team at CyVerse.</p>
-              <h2 id="how-atmosphere-is-tested"><a href="#how-atmosphere-is-tested">How Atmosphere is Tested</a></h2>
+              <h2 id="how-atmosphere-is-tested">How Atmosphere is Tested</h2>
               <p>The stack is tested at various levels; test coverage and the testing process is a work in progress.</p>
-              <h3 id="django-tests-in-atmosphere2"><a href="#django-tests-in-atmosphere2">Django tests in Atmosphere(2)</a></h3>
+              <h3 id="django-tests-in-atmosphere2">Django tests in Atmosphere(2)</h3>
               <p>Unit tests written by developers can be found throughout the codebase. These tests are not currently running as part of regular build/deploy workflow, but we could!</p>
-              <h3 id="travis-ci-running-style-bundlecompile-tests-for-troposphere"><a href="#travis-ci-running-style-bundlecompile-tests-for-troposphere"><a href="https://travis-ci.org/">Travis CI</a> running style &amp; bundle/compile tests for Troposphere</a></h3>
+              <h3 id="travis-ci-running-style-bundlecompile-tests-for-troposphere"><a href="https://travis-ci.org/">Travis CI</a> running style &amp; bundle/compile tests for Troposphere</h3>
               <ul>
               <li>see <a href="https://github.com/iPlantCollaborativeOpenSource/troposphere/blob/master/.travis.yml">.travis.yml</a> in Troposphere for configuration</li>
               <li><a href="https://travis-ci.org/iPlantCollaborativeOpenSource/troposphere">Troposphere test results on Travis CI</a></li>
               </ul>
-              <h3 id="qa-team-tests-using-robot-framework-and-jmeter"><a href="#qa-team-tests-using-robot-framework-and-jmeter">QA Team tests using Robot Framework and JMeter</a></h3>
+              <h3 id="qa-team-tests-using-robot-framework-and-jmeter">QA Team tests using Robot Framework and JMeter</h3>
               <p>Note that the following information describes processes performed by the QA Team at CyVerse who primarily support Atmosphere(0), but their effort certainly also benefits Atmosphere(1). This team is also responsible for testing other CyVerse products (e.g. Discovery Environment). Some resources described in this section are currently only accessiblt to members of CyVerse staff.</p>
               <p>Tests are built based on QA team using and reverse engineering Atmosphere(1) on atmobeta.cyverse.org, and the history of internal JIRA issues. QA team does not currently receive product specifications or release notes.</p>
               <p>Individual tests are tagged in a few dimensions:</p>
@@ -334,7 +334,7 @@
               <li>Troposphere UI (browser driven with Selenium)</li>
               </ul></li>
               </ul>
-              <p>atmobeta.cyverse.org is tested nightly, and test results can be found on <a href="https://shimerdas.iplantcollaborative.org:8443">https://shimerdas.iplantcollaborative.org:8443</a>. (You must be a member of CyVerse staff and on an internal network to access shimerdas Jenkins server.) Only atmobeta is targeted during <em>regression</em> testing.</p>
+              <p>atmobeta.cyverse.org is tested nightly, and test results can be found on <a href="https://shimerdas.iplantcollaborative.org:8443" class="uri">https://shimerdas.iplantcollaborative.org:8443</a>. (You must be a member of CyVerse staff and on an internal network to access shimerdas Jenkins server.) Only atmobeta is targeted during <em>regression</em> testing.</p>
               <p>atmo-dev.cyverse.org is tested as part of each continuous deployment. Jenkins runs tests against atmo-dev in two jobs (these links are only accessible to CyVerse staff):</p>
               <ul>
               <li><a href="https://atmo-dev.cyverse.org/jenkins/job/Test_Atmosphere/">Test_Atmosphere</a> (API tests)</li>
@@ -343,15 +343,15 @@
               <p>Test coverage is greater for the Atmosphere(2) API than for the Troposphere UI. QA team’s tests do not currently confirm that instances launch, nor do they execute the various instance access workflows (e.g. Web Shell and Web Desktop), but it is possible for this coverage to be added.</p>
               <p>If a test fails repeatedly, QA team files a JIRA ticket, tags the test with the JIRA number, and disables that test until the issue is resolved.</p>
               <p>More information on the QA team’s work can be found on <a href="http://qa-4.cyverse.org">qa-4.cyverse.org</a>, including the <a href="http://qa-4.cyverse.org/Atmosphere/">automated test suites</a> and how to run test suites locally (<a href="http://qa-4.cyverse.org/robotframework/misc/html/RobotFramework_and_iPlant.txt">1</a>, <a href="http://qa-4.cyverse.org/robotframework/misc/html/RobotFramework_Setup_for_iPlant-OLD.txt">2</a>). (Only accessible to CyVerse staff.) Note that much of the information is for other CyVerse projects, and some test framework dependencies are unnecessary if you are only testing Atmosphere.</p>
-              <h3 id="operation-sanity-behavioral-testing"><a href="#operation-sanity-behavioral-testing"><a href="https://github.com/cyverse/operation-sanity">Operation Sanity</a> behavioral testing</a></h3>
+              <h3 id="operation-sanity-behavioral-testing"><a href="https://github.com/cyverse/operation-sanity">Operation Sanity</a> behavioral testing</h3>
               <p>Operation Sanity is a set of test suites written using behave, which drive a browser using Selenium. Operation Sanity exercises common Atmosphere workflows as a user: launches several instances against multiple cloud providers, ensures that those instances launch, creates and attaches volumes, and so forth. It is intended to run these tests in parallel so that long operations (e.g. waiting for an instance to launch) do not block execution.</p>
               <p>Operation Sanity is currently in a “proof of concept” state, and is currently not run automatically. There is some intended functionality (e.g. testing launch of Web Shell and Web Desktop) which needs to be built.</p>
-              <h2 id="releases-and-development-cycles"><a href="#releases-and-development-cycles">Releases and Development Cycles</a></h2>
+              <h2 id="releases-and-development-cycles">Releases and Development Cycles</h2>
               <p>You can see a list of releases as branches in each GitHub repository, e.g. <a href="https://github.com/cyverse/atmosphere/branches">Atmosphere(2)</a>.</p>
-              <h3 id="release-naming-code-names"><a href="#release-naming-code-names">Release Naming &amp; “Code Names”</a></h3>
+              <h3 id="release-naming-code-names">Release Naming &amp; “Code Names”</h3>
               <p>Starting in August 2017, Atmosphere releases named by a number preceded by a “v”, <code>v27</code>. This marked the 27th major released of the product. Each major release will be incremented by one.</p>
               <p>Previously, the name was two words, a hyphen was be added between them. Hyphenated bird names used to be the golden ticket (Abyssinian-nightjar,california-condor) but we later allow for alliterative adjective/verb and bird name combinations (ex: jamming-junglefowl, mystifying-merlin, nautical-nighthawk). The final release using this naming approach was zesty-zapdos.</p>
-              <h3 id="approach-to-tagging-releases"><a href="#approach-to-tagging-releases">Approach to Tagging Releases</a></h3>
+              <h3 id="approach-to-tagging-releases">Approach to Tagging Releases</h3>
               <p>In order to identify which release a repository is associated with, we need to “tag”, or annotate, the association. Currently, we name branches by release for Atmosphere &amp; Troposphere. However, there are dependencies in the instance deployment automation managed in Atmosphere-Ansible repository. This repo is used by “subspace” via Atmosphere API - yet, we are not explicitly denoting the Atmosphere-Ansible tested, verified, and deployed with an Atmosphere release.</p>
               <p>I suggest that we use <a href="https://git-scm.com/book/en/v2/Git-Basics-Tagging#Annotated-Tags">“annotated-tags”</a> over lightweight tags; this allows for a “tag name” and a message.</p>
               <p>Given that we use an integer number preceded by ‘v’ for release names. So releases would be tagged <code>v##-1</code>. Subsequent patch release would increase by one: <code>v30-1</code>, <code>v30-2</code>, <code>v30-3</code>, …</p>
@@ -360,9 +360,9 @@
               <pre><code>
               GIT_TAG=&quot;v28-1&quot;
               git tag -a $GIT_TAG -m &quot;v28 (..release-codename..) release 1.&quot; &amp;&amp; git push origin --tags&lt;/pre&gt;</code></pre>
-              <h4 id="note-on-sequence"><a href="#note-on-sequence">Note on “Sequence”</a></h4>
+              <h4 id="note-on-sequence">Note on “Sequence”</h4>
               <p>The tag-name should be have preceding <code>v</code>, <em>“v for version”</em>, follow by a “two-digit” number that is an increasing integer representing the number of major releases of Atmosphere.</p>
-              <h4 id="what-should-be-tagged"><a href="#what-should-be-tagged">What Should Be Tagged?</a></h4>
+              <h4 id="what-should-be-tagged">What Should Be Tagged?</h4>
               <p>The repositories that <strong>should</strong> be tagged for a release are as follows:</p>
               <ul>
               <li>Atmosphere (<code>:release-name</code> branch) - <a href="https://github.com/cyverse/atmosphere">repo</a></li>
@@ -371,32 +371,32 @@
               <li>Clank (<code>master</code>) - <a href="https://github.com/cyverse/clank">repo</a></li>
               <li>nginx_novnc_auth (<code>master</code>) - <a href="https://github.com/cyverse/nginx_novnc_auth">repo</a></li>
               </ul>
-              <p>We should consider tagging this fork - <a href="https://github.com/edwins/gateone">https://github.com/edwins/gateone</a></p>
-              <h4 id="who-can-tag"><a href="#who-can-tag">Who Can Tag?</a></h4>
+              <p>We should consider tagging this fork - <a href="https://github.com/edwins/gateone" class="uri">https://github.com/edwins/gateone</a></p>
+              <h4 id="who-can-tag">Who Can Tag?</h4>
               <p>You have to be an admin of a repository to be able to tag releases. Ask an admin to create the tag if you don’t have access.</p>
-              <h3 id="release-structure"><a href="#release-structure">Release Structure</a></h3>
+              <h3 id="release-structure">Release Structure</h3>
               <p>The structure of releases is inspired by <a href="http://blog.assembla.com/AssemblaBlog/tabid/12618/bid/36341/Secrets-of-rapid-release-cycles-from-the-Google-Chrome-team.aspx">Chrome/Chromium</a>. We aim to deliver new code to production every 5 weeks. Those 5 weeks are split into 3 sprints (2 sprints of 2-weeks and a single 1-week sprint).</p>
-              <h4 id="first-2-week-sprint"><a href="#first-2-week-sprint">First 2-week Sprint</a></h4>
+              <h4 id="first-2-week-sprint">First 2-week Sprint</h4>
               <ul>
               <li>new feature development</li>
               <li>upgrading dependencies</li>
               <li>testing/verification</li>
               </ul>
-              <h4 id="second-2-week-sprint"><a href="#second-2-week-sprint">Second 2-week Sprint</a></h4>
+              <h4 id="second-2-week-sprint">Second 2-week Sprint</h4>
               <ul>
               <li>Priority bug fixes</li>
               <li>feature development <em>continued</em></li>
               <li>testing/verification</li>
               </ul>
-              <h4 id="third-1-week-sprint"><a href="#third-1-week-sprint">Third 1-week Sprint</a></h4>
+              <h4 id="third-1-week-sprint">Third 1-week Sprint</h4>
               <ul>
               <li>Any committed works left to finish</li>
               <li>Priority/Critical tickets</li>
               <li>testing/verification</li>
               </ul>
-              <h3 id="code-branching-strategy"><a href="#code-branching-strategy">Code Branching Strategy</a></h3>
+              <h3 id="code-branching-strategy">Code Branching Strategy</h3>
               <p>(Note that the following section contains links to environments that are only accessible to members of CyVerse staff.)</p>
-              <p>The master branch collects new feature development and community contributions. <a href="http://atmo-dev.cyverse.org">http://atmo-dev.cyverse.org</a> generally tracks master. Other feature branches are used as needed.</p>
+              <p>The master branch collects new feature development and community contributions. <a href="http://atmo-dev.cyverse.org" class="uri">http://atmo-dev.cyverse.org</a> generally tracks master. Other feature branches are used as needed.</p>
               <p>The ‘beta’ / ‘next release’ branch collects stability improvements and bug fixes; it does not typically receive new features. <a href="http://atmobeta.cyverse.org/">http://atmobeta.cyverse.org</a> generally tracks the next release.</p>
               <p>Think of each five-week cycle as an effort to 1. develop new features on the master branch, and 2. stabilize the beta/release branch for deployment to production.</p>
               <p>Bug fixes and other changes are regularly “trickled down” from the beta/release branch to the master branch, and when necessary, from production systems to beta/release.</p>

--- a/dist/staff_guide.html
+++ b/dist/staff_guide.html
@@ -8,46 +8,74 @@
         <meta http-equiv="Content-Style-Type" content="text/css" />
         <meta name="generator" content="pandoc" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-                    <title></title>
+                    <title>00_introduction</title>
         <style type="text/css">code{white-space: pre;}</style>
                     <style type="text/css">
-      div.sourceCode { overflow-x: auto; }
-      table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode {
-        margin: 0; padding: 0; vertical-align: baseline; border: none; }
-      table.sourceCode { width: 100%; line-height: 100%; }
-      td.lineNumbers { text-align: right; padding-right: 4px; padding-left: 4px; color: #aaaaaa; border-right: 1px solid #aaaaaa; }
-      td.sourceCode { padding-left: 5px; }
-      code > span.kw { color: #007020; font-weight: bold; } /* Keyword */
-      code > span.dt { color: #902000; } /* DataType */
-      code > span.dv { color: #40a070; } /* DecVal */
-      code > span.bn { color: #40a070; } /* BaseN */
-      code > span.fl { color: #40a070; } /* Float */
-      code > span.ch { color: #4070a0; } /* Char */
-      code > span.st { color: #4070a0; } /* String */
-      code > span.co { color: #60a0b0; font-style: italic; } /* Comment */
-      code > span.ot { color: #007020; } /* Other */
-      code > span.al { color: #ff0000; font-weight: bold; } /* Alert */
-      code > span.fu { color: #06287e; } /* Function */
-      code > span.er { color: #ff0000; font-weight: bold; } /* Error */
-      code > span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
-      code > span.cn { color: #880000; } /* Constant */
-      code > span.sc { color: #4070a0; } /* SpecialChar */
-      code > span.vs { color: #4070a0; } /* VerbatimString */
-      code > span.ss { color: #bb6688; } /* SpecialString */
-      code > span.im { } /* Import */
-      code > span.va { color: #19177c; } /* Variable */
-      code > span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
-      code > span.op { color: #666666; } /* Operator */
-      code > span.bu { } /* BuiltIn */
-      code > span.ex { } /* Extension */
-      code > span.pp { color: #bc7a00; } /* Preprocessor */
-      code > span.at { color: #7d9029; } /* Attribute */
-      code > span.do { color: #ba2121; font-style: italic; } /* Documentation */
-      code > span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
-      code > span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
-      code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+      a.sourceLine { display: inline-block; line-height: 1.25; }
+      a.sourceLine { pointer-events: none; color: inherit; text-decoration: inherit; }
+      a.sourceLine:empty { height: 1.2em; position: absolute; }
+      .sourceCode { overflow: visible; }
+      code.sourceCode { white-space: pre; position: relative; }
+      div.sourceCode { margin: 1em 0; }
+      pre.sourceCode { margin: 0; }
+      @media screen {
+      div.sourceCode { overflow: auto; }
+      }
+      @media print {
+      code.sourceCode { white-space: pre-wrap; }
+      a.sourceLine { text-indent: -1em; padding-left: 1em; }
+      }
+      pre.numberSource a.sourceLine
+        { position: relative; }
+      pre.numberSource a.sourceLine:empty
+        { position: absolute; }
+      pre.numberSource a.sourceLine::before
+        { content: attr(data-line-number);
+          position: absolute; left: -5em; text-align: right; vertical-align: baseline;
+          border: none; pointer-events: all;
+          -webkit-touch-callout: none; -webkit-user-select: none;
+          -khtml-user-select: none; -moz-user-select: none;
+          -ms-user-select: none; user-select: none;
+          padding: 0 4px; width: 4em;
+          color: #aaaaaa;
+        }
+      pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+      div.sourceCode
+        {  }
+      @media screen {
+      a.sourceLine::before { text-decoration: underline; }
+      }
+      code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+      code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+      code span.at { color: #7d9029; } /* Attribute */
+      code span.bn { color: #40a070; } /* BaseN */
+      code span.bu { } /* BuiltIn */
+      code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+      code span.ch { color: #4070a0; } /* Char */
+      code span.cn { color: #880000; } /* Constant */
+      code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+      code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+      code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+      code span.dt { color: #902000; } /* DataType */
+      code span.dv { color: #40a070; } /* DecVal */
+      code span.er { color: #ff0000; font-weight: bold; } /* Error */
+      code span.ex { } /* Extension */
+      code span.fl { color: #40a070; } /* Float */
+      code span.fu { color: #06287e; } /* Function */
+      code span.im { } /* Import */
+      code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+      code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+      code span.op { color: #666666; } /* Operator */
+      code span.ot { color: #007020; } /* Other */
+      code span.pp { color: #bc7a00; } /* Preprocessor */
+      code span.sc { color: #4070a0; } /* SpecialChar */
+      code span.ss { color: #bb6688; } /* SpecialString */
+      code span.st { color: #4070a0; } /* String */
+      code span.va { color: #19177c; } /* Variable */
+      code span.vs { color: #4070a0; } /* VerbatimString */
+      code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
         </style>
-                    <link rel="stylesheet" href="./themes/cyverse/templates/main.css" type="text/css" />
+                    <link rel="stylesheet" href="./themes/cyverse/templates/main.css" />
                     <link rel="icon" href="themes/cyverse/media/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" href="themes/cyverse/media/css/normalize.min.css">
         <link rel="stylesheet" href="themes/cyverse/media/css/main.css">
@@ -155,30 +183,30 @@
               </ul>
               <h3 id="how-do-i-grant-staff-access-to-the-atmosphere-apis-to-user-x">How do I grant Staff access to the Atmosphere APIs to User X?</h3>
               <p>To get to Atmosphere’s Python REPL:</p>
-              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">cd</span> /opt/dev/atmosphere <span class="co"># References the canonical &#39;dev&#39; path.</span>
-              <span class="kw">source</span> /opt/env/atmo/bin/activate  <span class="co"># References the canonical &#39;env&#39; path.</span>
-              <span class="kw">./manage.py</span> shell</code></pre></div>
+              <div class="sourceCode" id="cb1"><pre class="sourceCode bash"><code class="sourceCode bash"><a class="sourceLine" id="cb1-1" data-line-number="1"><span class="bu">cd</span> /opt/dev/atmosphere <span class="co"># References the canonical &#39;dev&#39; path.</span></a>
+              <a class="sourceLine" id="cb1-2" data-line-number="2"><span class="bu">source</span> /opt/env/atmo/bin/activate  # References the canonical <span class="st">&#39;env&#39;</span> path.</a>
+              <a class="sourceLine" id="cb1-3" data-line-number="3"><span class="ex">./manage.py</span> shell</a></code></pre></div>
               <p>Once inside Atmosphere’s Python REPL:</p>
-              <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python"><span class="im">from</span> core.models <span class="im">import</span> AtmosphereUser
-              user <span class="op">=</span> AtmosphereUser.objects.get(username<span class="op">=</span><span class="st">&#39;x&#39;</span>)
-              user.is_staff <span class="op">=</span> <span class="va">True</span>
-              user.is_superuser <span class="op">=</span> <span class="va">True</span>
-              user.save()
-              
-              <span class="co"># To set the users password at the same time</span>
-              <span class="co"># (This is required if you want /admin access without LDAP)</span>
-              <span class="co"># user.set_password(&#39;new_password&#39;)</span></code></pre></div>
+              <div class="sourceCode" id="cb2"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb2-1" data-line-number="1"><span class="im">from</span> core.models <span class="im">import</span> AtmosphereUser</a>
+              <a class="sourceLine" id="cb2-2" data-line-number="2">user <span class="op">=</span> AtmosphereUser.objects.get(username<span class="op">=</span><span class="st">&#39;x&#39;</span>)</a>
+              <a class="sourceLine" id="cb2-3" data-line-number="3">user.is_staff <span class="op">=</span> <span class="va">True</span></a>
+              <a class="sourceLine" id="cb2-4" data-line-number="4">user.is_superuser <span class="op">=</span> <span class="va">True</span></a>
+              <a class="sourceLine" id="cb2-5" data-line-number="5">user.save()</a>
+              <a class="sourceLine" id="cb2-6" data-line-number="6"></a>
+              <a class="sourceLine" id="cb2-7" data-line-number="7"><span class="co"># To set the users password at the same time</span></a>
+              <a class="sourceLine" id="cb2-8" data-line-number="8"><span class="co"># (This is required if you want /admin access without LDAP)</span></a>
+              <a class="sourceLine" id="cb2-9" data-line-number="9"><span class="co"># user.set_password(&#39;new_password&#39;)</span></a></code></pre></div>
               <h3 id="how-do-i-grant-staff-access-to-the-troposphere-admin-pages-to-user-x">How do I grant Staff access to the Troposphere Admin pages to User X?</h3>
               <p>To get to Troposphere’s Python REPL:</p>
-              <div class="sourceCode"><pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">cd</span> /opt/dev/troposphere <span class="co"># References the canonical &#39;dev&#39; path.</span>
-              <span class="kw">source</span> /opt/env/troposphere/bin/activate  <span class="co"># References the canonical &#39;env&#39; path.</span>
-              <span class="kw">./manage.py</span> shell</code></pre></div>
+              <div class="sourceCode" id="cb3"><pre class="sourceCode bash"><code class="sourceCode bash"><a class="sourceLine" id="cb3-1" data-line-number="1"><span class="bu">cd</span> /opt/dev/troposphere <span class="co"># References the canonical &#39;dev&#39; path.</span></a>
+              <a class="sourceLine" id="cb3-2" data-line-number="2"><span class="bu">source</span> /opt/env/troposphere/bin/activate  # References the canonical <span class="st">&#39;env&#39;</span> path.</a>
+              <a class="sourceLine" id="cb3-3" data-line-number="3"><span class="ex">./manage.py</span> shell</a></code></pre></div>
               <p>Once inside troposphere’s Python REPL:</p>
-              <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python"><span class="im">from</span> django.contrib.auth.models <span class="im">import</span> User
-              user <span class="op">=</span> User.objects.get(username<span class="op">=</span><span class="st">&#39;x&#39;</span>)
-              user.is_staff <span class="op">=</span> <span class="va">True</span>
-              user.is_superuser <span class="op">=</span> <span class="va">True</span>
-              user.save()</code></pre></div>
+              <div class="sourceCode" id="cb4"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb4-1" data-line-number="1"><span class="im">from</span> django.contrib.auth.models <span class="im">import</span> User</a>
+              <a class="sourceLine" id="cb4-2" data-line-number="2">user <span class="op">=</span> User.objects.get(username<span class="op">=</span><span class="st">&#39;x&#39;</span>)</a>
+              <a class="sourceLine" id="cb4-3" data-line-number="3">user.is_staff <span class="op">=</span> <span class="va">True</span></a>
+              <a class="sourceLine" id="cb4-4" data-line-number="4">user.is_superuser <span class="op">=</span> <span class="va">True</span></a>
+              <a class="sourceLine" id="cb4-5" data-line-number="5">user.save()</a></code></pre></div>
               <h2 id="accessing-the-django-administration-pages">Accessing the Django Administration Pages</h2>
               <p><a name="staff_django_admin"></a></p>
               <h3 id="first-a-warning-about-django-administration-pages">First, A warning about Django Administration Pages</h3>
@@ -208,19 +236,16 @@
               <p><strong>To emulate a user, you must first log in to Troposphere as a staff user.</strong> First, login normally as the staff user. Next, navigate to this page in your browser: <code>https://&lt;your_url&gt;/application/emulate/&lt;username&gt;</code></p>
               <p>After a series of redirections, you should see that the username in the Top Right corner has changed to the user you are intending to emulate. If you are unable to emulate a user after several attempts, ensure that the username exists and is spelled properly.</p>
               <p>Note: You can also emulate from “Admin &gt; Manage Users”.</p>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li>Click on the “Admin” tab within the header</li>
               <li>Click on “Manage Users”</li>
               <li>Search by <em>username</em></li>
               <li>Click on the “user” icon to the left of <em>username</em></li>
               </ol>
-              <div class="figure">
-              <img src="./media/emulate-from-admin-tab.png" />
-              
-              </div>
+              <p><img src="./media/emulate-from-admin-tab.png" /></p>
               <h5 id="unemulate-a-user">Unemulate a user:</h5>
               <p><a name="staff_no_emulate_ui"></a> When done emulating a user, there are several options to ‘disconnect’ from the session:</p>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li>navigate to <code>https://&lt;your_url&gt;/application/emulate/&lt;your_username&gt;</code></li>
               <li>navigate to <code>https://&lt;your_url&gt;/application/emulate</code> (NOTE: no username after <code>emulate</code>.)</li>
               </ol>
@@ -279,37 +304,37 @@
               <strong>Do Not</strong> edit the existing quota.</p>
               <h5 id="example">Example:</h5>
               <p><a name="allocation-example"></a> How to grant a quota or allocation from the Django Admin panel:</p>
-              <div class="figure">
-              <img src="./media/adjust_quota_allocation_from_admin.gif" alt="Granting Allocation/Quota via Django Admin" />
-              <p class="caption">Granting Allocation/Quota via Django Admin</p>
-              </div>
+              <figure>
+              <img src="./media/adjust_quota_allocation_from_admin.gif" alt="Granting Allocation/Quota via Django Admin" /><figcaption>Granting Allocation/Quota via Django Admin</figcaption>
+              </figure>
               <h3 id="imaging-requests">Imaging Requests</h3>
               <p>This will take you through how to login to atmosphere via the Troposphere UI admin interface and approve an imaging request. <strong>WARNING: At most one machine request should be in the ‘started’ or ‘imaging’ state at a time. Failure to follow these rules could potentially cause filesystem trouble. You have been warned.</strong></p>
               <h4 id="approving-a-pending-machine-request">Approving a ‘pending’ Machine Request</h4>
               <p>Describe the process, step by step, of how to login to Atmosphere via the Troposphere UI. Select the admin panel Select Machine Requests Click ‘approve’</p>
               <h4 id="approving-a-machine-request-including-those-in-error">Approving a Machine Request (Including those in ERROR)</h4>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li>Login as a staff user who has access to the Troposphere Admin Panel</li>
               <li>Select ‘Imaging Requests’ for a list of active requests.</li>
               <li>To Approve a Machine Request that is in a state other than <em>pending</em>, first select ‘re-submit’</li>
               <li>To start the Machine Request immediately, Click ‘approve’. Being sure to pay attention to the warning above that <em>ONLY ONE</em> request should be in the <code>imaging</code> state.</li>
               <li>After approving a machine request, return ~15-20minutes later and ensure the request was successful. If not, see “Troubleshooting Imaging Requests” below.</li>
               </ol>
-              <div class="figure">
-              <img src="./media/staff_how_to_approve_imaging_requests.gif" />
-              
-              </div>
+              <p><img src="./media/staff_how_to_approve_imaging_requests.gif" /></p>
               <h4 id="troubleshooting-imaging-requests">Troubleshooting Imaging Requests</h4>
               <p>Usually the Imaging Request process is 100% automated. Occasionally though, you will find the request is in (ERROR).</p>
               <h5 id="fixing-an-imaging-request-in-the-error-state">Fixing an Imaging Request in the (ERROR) state</h5>
               <ul>
-              <li>If the MachineRequest throws an exception and the (Status Message) shows: (validating) Error …</li>
+              <li>If the MachineRequest throws an exception and the (Status Message) shows: (validating) Error …
+              <ul>
               <li>Including the text: “Maximum number of instances exceeded”</li>
+              </ul></li>
               </ul>
               <p>Ask a System Administrator to remove the instances from the <code>atmosphere admin</code> user and tenant. (This problem will be automated away shortly)</p>
               <ul>
-              <li>If the MachineRequest throws an exception and the (Status Message) shows: (processing - <IMAGE_ID>) Error … (validating) Error …</li>
+              <li>If the MachineRequest throws an exception and the (Status Message) shows: (processing - <IMAGE_ID>) Error … (validating) Error …
+              <ul>
               <li>Especially: <code>AttributeError: \'NoneType\' object has no attribute \'id\'\n'</code></li>
+              </ul></li>
               </ul>
               <p>See ‘Fixing a request in the <code>processing</code> or <code>validating</code> state.’.</p>
               <ul>
@@ -415,7 +440,7 @@
               <li>The instance is <em>online</em> and <em>reachable via SSH</em>, but the SSH key did not properly deploy to the instance on first boot.</li>
               <li>If after &gt;2 hours, one of these three conditions is still resulting in failure, the instance will move to <a href="#deploy_error">deploy_error</a>.</li>
               </ul>
-              <ol style="list-style-type: decimal">
+              <ol type="1">
               <li>A common resolution to an instance stuck in networking is to reboot it from the Tropospere UI while <a href="#">emulating</a> as the user experiencing the issue. If the instance gets stuck in networking again, proceed to step 2.</li>
               <li>If an instance is stuck in networking, you can check <a href="#">flower</a> to see current celery tasks and find the instance in question. If there is an error, flower will display it and you can diagnore the issue from there.</li>
               </ol>
@@ -427,7 +452,8 @@
               <p><a name='deploy_error'></a> 1. In the case of a deploy error, the most common course of action is to emulate as the user facing the issue and click the “Redeploy” button from the instance in question’s detail page. If the instance reaches another deploy error, move on to step 2. 2. In some cases, a reboot of the instance will resolve a deploy error. You can try rebooting the instance from the instance’s detail page by clicking on the “reboot” button. If for some reason a soft reboot fails, try a hard reboot. If the instance comes back to deploy error, move on to step 3. 3. Check the <a href="#logs">deploy logs</a> and look for the instance ID to see the output of which specifc tasks failed. From here, you can try to resolve the issue manually and redeploy. To easily check the realtime status of an instance’s deploy process, you can use <code>tail -f &lt;deploy_log_file&gt; | grep &lt;instance_alias&gt;</code></p>
               <h2 id="contacting-the-atmosphere-team">Contacting the Atmosphere Team</h2>
               <ul>
-              <li><p>You will likely need to contact the system administrator of the cloud and/or the atmosphere team for futher intervention. Please be sure to provide this information <strong>at a minimum</strong> to ensure your request can be answered in a timely fashion:</p>
+              <li>You will likely need to contact the system administrator of the cloud and/or the atmosphere team for futher intervention. Please be sure to provide this information <strong>at a minimum</strong> to ensure your request can be answered in a timely fashion:</li>
+              </ul>
               <pre><code>Username:
               Instance ID:
               IP Address:
@@ -436,8 +462,7 @@
               Size selected:
               Fault message from nova:
               Additional notes from triage:</code></pre>
-              <p>This information will allow more advanced users to reproduce your problem and find a solution without contacting you a second/third time.</p></li>
-              </ul>
+              <p>This information will allow more advanced users to reproduce your problem and find a solution without contacting you a second/third time.</p>
               <h2 id="flower">Flower</h2>
               <p><a name='flower'>Flower</a> is a web based tool for monitoring and administrating Celery workers and tasks.</p>
               <h3 id="logging-in-to-flower">Logging in to flower</h3>
@@ -453,10 +478,9 @@
               <p>View the status of recent celery tasks by clicking on the “Tasks” tab.</p>
               <p>Search over the list of celery tasks by writing the <code>instance_id</code> or <code>username</code> into the search bar on the Top-Right corner. View the fine-grained details of a task by clicking on the task <code>Name</code>. The most important details are: <code>Traceback</code> (Finding the bug/failure), <code>Worker</code> (Finding the logs).</p>
               <p>You can view tasks by status by clicking on the “Monitor” tab and clicking on your desired task state.</p>
-              <div class="figure">
-              <img src="./media/staff_flower_login.gif" alt="Example login to flower" />
-              <p class="caption">Example login to flower</p>
-              </div>
+              <figure>
+              <img src="./media/staff_flower_login.gif" alt="Example login to flower" /><figcaption>Example login to flower</figcaption>
+              </figure>
               <h2 id="administering-applications-and-images">Administering Applications and Images</h2>
               <h3 id="migrating-applicationimage-to-a-new-cloud-provider">Migrating Application/Image to a New Cloud Provider</h3>
               <p>You may have multiple cloud providers connected to your deployment, and you wish to make an existing Application (a.k.a. image) available on a new provider. This process is automated by <code>application_to_provider.py</code> in Atmosphere(2)’s <code>scripts/</code> folder.</p>

--- a/dist/user_guide.html
+++ b/dist/user_guide.html
@@ -8,9 +8,9 @@
         <meta http-equiv="Content-Style-Type" content="text/css" />
         <meta name="generator" content="pandoc" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-                    <title></title>
+                    <title>allocation</title>
         <style type="text/css">code{white-space: pre;}</style>
-                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" type="text/css" />
+                          <link rel="stylesheet" href="./themes/cyverse/templates/main.css" />
                     <link rel="icon" href="themes/cyverse/media/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" href="themes/cyverse/media/css/normalize.min.css">
         <link rel="stylesheet" href="themes/cyverse/media/css/main.css">
@@ -51,11 +51,9 @@
                               <!-- MAIN CONTENT -->
               <article>
               <p>This will take you through the process of requesting additional resources.</p>
-              <h1 id="navigate-to-the-request-form"><a href="#navigate-to-the-request-form">Navigate to the request form</a></h1>
-              <div class="figure">
-              <img src="./media/navigate_to_resource_request_form.gif" />
-              </div>
-              <h1 id="requesting-more-resources"><a href="#requesting-more-resources">Requesting more resources</a></h1>
+              <h1 id="navigate-to-the-request-form">Navigate to the request form</h1>
+              <p><img src="./media/navigate_to_resource_request_form.gif" /></p>
+              <h1 id="requesting-more-resources">Requesting more resources</h1>
               <p>There are two forms of resources: <strong>Allocation</strong> and <strong>Quota</strong>.</p>
               <p><strong>Allocation</strong> is a monthly allotment of time that we allow your virtual machines to run. One of our allocation units (AU) is an hour per cpu of your machine. A 1 cpu machine will consume 1AU for every hour it is active. A 16 cpu machine will consume 16AU per hour. Keep in mind that larger machines need to be suspended often to conserve your AU budget. See <a href="#calculate-au">Calculating desired AU</a>. Allocation is reset every month (it does not carry over).</p>
               <p><strong>Quota</strong> are constraints on resources that don’t change on a monthly basis.</p>
@@ -68,22 +66,20 @@
               </ul>
               <p>You can request an increase of Allocation and Quota to the discretion of the support staff. Motivate why the additonal resources are needed in the form above.</p>
               <p>After you submit the form, support will get in touch with you about the status of your request.</p>
-              <h1 id="calculating-desired-au"><a href="#calculating-desired-au">Calculating desired AU <a name="calculate-au">🔗</a></a></h1>
-              <div class="figure">
-              <img src="./media/au-calculator.gif" />
-              </div>
-              <h1 id="what-is-a-boot-script-and-why-would-you-use-it"><a href="#what-is-a-boot-script-and-why-would-you-use-it">What is a Boot Script and why would you use it</a></h1>
+              <h1 id="calculating-desired-au">Calculating desired AU <a name="calculate-au">🔗</a></h1>
+              <p><img src="./media/au-calculator.gif" /></p>
+              <h1 id="what-is-a-boot-script-and-why-would-you-use-it">What is a Boot Script and why would you use it</h1>
               <p>Boot scripts are a way to dynamically modify the environment of your VM at run time.</p>
               <p>Boot scripts can be created for a specific instance Boot scripts can also be created to execute on a new machine (via Machine Request) for all users who launch that VM.</p>
               <p>Boot scripts are executed by the Atmosphere system as the <em>final</em> step of the deployment process.</p>
               <p>These scripts can be used to: - execute a daemon/background processes - change permissions of a directory to match the active running user, rather than your own account.</p>
               <p>These scripts should <em>NOT</em> be used to: - Install new dependencies (Instead, install the software you want and create a Machine Request)</p>
               <p>NOTE: A failure of a boot script may cause your VM to behave in an unexpected way, but time will still be counted against you. Make sure that you test your boot scripts multiple times before distributing it with your VM.</p>
-              <h1 id="variables-that-are-included-in-your-boot-script"><a href="#variables-that-are-included-in-your-boot-script">Variables that are included in your boot script</a></h1>
+              <h1 id="variables-that-are-included-in-your-boot-script">Variables that are included in your boot script</h1>
               <ul>
               <li>ATMO_USER: This is the username of the account that is running your Image/Instance.</li>
               </ul>
-              <h1 id="examples-of-a-full-text-boot-script"><a href="#examples-of-a-full-text-boot-script">Examples of a ‘Full Text’ boot script</a></h1>
+              <h1 id="examples-of-a-full-text-boot-script">Examples of a ‘Full Text’ boot script</h1>
               <p>A Full text boot script should include a shebang line to tell the bash console what program to use. The script will be executed directly.</p>
               <p>Using the templated variables above can be very helpful for creating dynamic boot scripts.</p>
               <pre><code>#!/bin/bash -x
@@ -133,31 +129,25 @@
               
               # This line will start the execution of the script
               main</code></pre>
-              <h1 id="examples-of-a-url-boot-script"><a href="#examples-of-a-url-boot-script">Examples of a ‘URL’ boot script</a></h1>
+              <h1 id="examples-of-a-url-boot-script">Examples of a ‘URL’ boot script</h1>
               <p>A URL boot script should start with http or https. A URL boot script should point to the <em>RAW</em> file The file the boot script points to should follow all rules listed in <em>Examples of a Full Text boot script</em></p>
               <pre><code>https://raw.githubusercontent.com/iPlantCollaborativeOpenSource/atmosphere/master/core/examples/boot_scripts/grant_permissions.sh</code></pre>
               <p>This will take you through the process of creating an image.</p>
-              <h1 id="about-requesting-an-image"><a href="#about-requesting-an-image">About requesting an image</a></h1>
+              <h1 id="about-requesting-an-image">About requesting an image</h1>
               <p>An image is a type of template for a virtual machine. You can launch an instance and install the software and files you want to use, then request an image of the instance using the Request Imaging from within Atmosphere, as outlined below. This allows you to retain a complete copy of all of the changes and updates you made to the instance so you can reuse it again later, much like a template.</p>
               <p><strong>WARNING: <span style="color:red;">It is easy to include sensitive data in a public image.</span></strong></p>
               <p>For other security concerns consult this <a href="https://pods.iplantcollaborative.org/wiki/display/atmman/Requesting+an+Image+of+an+Instance">guide</a>.</p>
-              <h1 id="navigate-to-the-request-form-1"><a href="#navigate-to-the-request-form-1">Navigate to the request form</a></h1>
-              <div class="figure">
-              <img src="./media/navigate-to-image-request.gif" />
-              </div>
-              <h1 id="submitting-an-imaging-request"><a href="#submitting-an-imaging-request">Submitting an imaging request</a></h1>
+              <h1 id="navigate-to-the-request-form-1">Navigate to the request form</h1>
+              <p><img src="./media/navigate-to-image-request.gif" /></p>
+              <h1 id="submitting-an-imaging-request">Submitting an imaging request</h1>
               <p>Each step has accompanying instructions. After your request has been submitted. Support will get in touch with you about the status of your image request. For more comprehensive documentation consult this <a href="https://pods.iplantcollaborative.org/wiki/display/atmman/Requesting+an+Image+of+an+Instance">guide</a>.</p>
-              <h1 id="viewing-pending-image-requests"><a href="#viewing-pending-image-requests">Viewing pending image requests</a></h1>
+              <h1 id="viewing-pending-image-requests">Viewing pending image requests</h1>
               <p>This animation illustrates viewing a recently submitted request.</p>
-              <div class="figure">
-              <img src="./media/submit-image-request-and-view-pending-requests.gif" />
-              </div>
+              <p><img src="./media/submit-image-request-and-view-pending-requests.gif" /></p>
               <p>This will take you through the login process.</p>
-              <h1 id="logging-in"><a href="#logging-in">Logging in</a></h1>
+              <h1 id="logging-in">Logging in</h1>
               <p>Navigate to the home page, click login.</p>
-              <div class="figure">
-              <img src="./media/login.gif" />
-              </div>
+              <p><img src="./media/login.gif" /></p>
               </article>
             </div> <!-- #main -->
         </div> <!-- #main-container -->

--- a/scripts/to_html_template.sh
+++ b/scripts/to_html_template.sh
@@ -7,7 +7,7 @@
 if [ -z "$THEME_NAME" ]; then
   THEME_NAME="cyverse"
 fi
-#NOTE: THEME_PATH is *ALWAYS* relative to the dist/ directory -- 
+#NOTE: THEME_PATH is *ALWAYS* relative to the dist/ directory --
 if [ -z "$THEME_PATH" ]; then
   THEME_PATH="./themes/$THEME_NAME"
 fi
@@ -24,7 +24,7 @@ function run_pandoc {
         -H "./dist/$THEME_PATH/templates/headers.html"\
         -A "./dist/$THEME_PATH/templates/footer.html"\
         -c "./themes/$THEME_NAME/templates/main.css"\
-        --standalone -S --toc --toc-depth 4\
+        --standalone -smart --toc --toc-depth 4\
         -t "html" -o "./dist/${SECTION}.html"
 }
 

--- a/src/index/00_welcome.md
+++ b/src/index/00_welcome.md
@@ -13,6 +13,7 @@ This site hosts documentation for Atmosphere, the free, open-source cloud comput
 
 ## For Users
 
+- [Getting Started](./getting_started.html)
 - [User Guide](./user_guide.html)
 - [Imaging Guide](./imaging_guide.html)
 


### PR DESCRIPTION
## Description

I noticed that the "Getting Started" page was not shown in the index, so this PR adds it.

When trying to compile, I got the error: `--smart/-S has been removed.  Use +smart or -smart extension instead.` so I changed the script to use the `-smart` option instead of `-S`
Let me know if I should undo this.

Currently compiled and hosted here: https://calvinmclean.github.io/atmosphere-guides/

Possible problems:
- The title of the page (show in tabs) is now the name of the HTML file: `00_welcome` is the title of the index page. This is explained by this error during compile: `[WARNING] This document format requires a nonempty <title> element.`

## Checklist before merging Pull Requests
- [ ] If providing a step-by-step procedure (e.g. a set of commands to run), *try following your own steps*, ensure they produce the intended result
- [x] Run makefile to compile your changes into the guide (see "Compiling Docs" in README.md)
- [ ] Verify that the compiled changes look accurate by viewing the HTML site
- [ ] Have at least one other contributor review and approve your changes
