### PR TITLE
Problem: Inline code (`wow`) renders as block code

### DIFF
--- a/dist/themes/cyverse/templates/main.css
+++ b/dist/themes/cyverse/templates/main.css
@@ -33,25 +33,23 @@ article img {
     width: 100%;
 }
 
+code {
+  /*
+      TODO: normalize.min.css is imported after this file which
+      is wrong. Will look into fixing that and removing this
+      !important rule later
+  */
+  font-size: .9em !important;
+  background: rgba(0,0,0,0.03);
+  padding: 5px;
+}
+
 pre code {
     line-height: 1.2;
     display: block;
     overFlow: scroll;
     padding: 10px;
-    /*
-        TODO: normalize.min.css is imported after this file which
-        is wrong. Will look into fixing that and removing this
-        !important rule later
-    */
-    font-size: .9em !important;
     border-left: solid rgba(0,0,0,.08) 5px;
-    background: rgba(0,0,0,0.03);
-}
-
-code {
-  font-size: .9em !important;
-  background: rgba(0,0,0,0.03);
-  padding: 5px;
 }
 
 audio,

--- a/dist/themes/cyverse/templates/main.css
+++ b/dist/themes/cyverse/templates/main.css
@@ -33,12 +33,12 @@ article img {
     width: 100%;
 }
 
-code {
+pre code {
     line-height: 1.2;
     display: block;
     overFlow: scroll;
     padding: 10px;
-    /* 
+    /*
         TODO: normalize.min.css is imported after this file which
         is wrong. Will look into fixing that and removing this
         !important rule later
@@ -46,6 +46,12 @@ code {
     font-size: .9em !important;
     border-left: solid rgba(0,0,0,.08) 5px;
     background: rgba(0,0,0,0.03);
+}
+
+code {
+  font-size: .9em !important;
+  background: rgba(0,0,0,0.03);
+  padding: 5px;
 }
 
 audio,
@@ -188,7 +194,7 @@ aside a:hover {
 
 
 .footer-container footer {
-    
+
     padding: 4px 0;
 }
 

--- a/dist/themes/jetstream/templates/main.css
+++ b/dist/themes/jetstream/templates/main.css
@@ -34,18 +34,22 @@ article img {
 }
 
 code {
+  /*
+      TODO: normalize.min.css is imported after this file which
+      is wrong. Will look into fixing that and removing this
+      !important rule later
+  */
+  font-size: .9em !important;
+  background: rgba(0,0,0,0.03);
+  padding: 5px;
+}
+
+pre code {
     line-height: 1.2;
     display: block;
     overFlow: scroll;
     padding: 10px;
-    /* 
-        TODO: normalize.min.css is imported after this file which
-        is wrong. Will look into fixing that and removing this
-        !important rule later
-    */
-    font-size: .9em !important;
     border-left: solid rgba(0,0,0,.08) 5px;
-    background: rgba(0,0,0,0.03);
 }
 
 audio,
@@ -188,7 +192,7 @@ aside a:hover {
 
 
 .footer-container footer {
-    
+
     padding: 4px 0;
 }
 


### PR DESCRIPTION
## Description

Inline code (`like this one`) is rendered to show as blocks. This PR fixes it to show them inline.

When the HTML is rendered, inline code is put in `<code></code>` and code blocks are nested in 

```
<pre>
  <code></code>
</pre>
```

So the changes to CSS in PR #30 change both the inline and block code formatting. This PR changes the CSS selector to be `pre code` instead of just `code`. I also added a `code` CSS selector to make inline code smaller font and grey background (same as blocks).

Before:
![screen shot 2018-02-19 at 11 15 33 am](https://user-images.githubusercontent.com/19335917/36392051-9777a8ce-1566-11e8-9f6f-cd7d04535318.png)

After:
![screen shot 2018-02-19 at 11 12 25 am](https://user-images.githubusercontent.com/19335917/36392058-9c3cb9d0-1566-11e8-847e-683cd005def7.png)

## Checklist before merging Pull Requests
- [x] Run makefile to compile your changes into the guide (see "Compiling Docs" in README.md)
- [x] Verify that the compiled changes look accurate by viewing the HTML site
- [ ] Have at least one other contributor review and approve your changes
