### PR TITLE
Fix code block indentation (Issue #29)

### DIFF
--- a/templates/html/bootstrap.html
+++ b/templates/html/bootstrap.html
@@ -51,7 +51,7 @@
                 $endif$
               <!-- MAIN CONTENT -->
               <article>
-              $body$
+$body$
               </article>
             </div> <!-- #main -->
         </div> <!-- #main-container -->


### PR DESCRIPTION
## Description

After first line of code blocks, the rest would be indented unintentionally.
This is because each line is contained in a `<pre>` tag that considers pre-
formatted text and will render indentation in the HTML. Fixed by unindenting
`$body$` in the template.

Fixes Issue #29 

For some reason I cannot get the changes to upload to https://calvinmclean.github.io/atmosphere-guides, but the fix works locally

## Checklist before merging Pull Requests
- ~[ ] If providing a step-by-step procedure (e.g. a set of commands to run), *try following your own steps*, ensure they produce the intended result~
- [x] Run makefile to compile your changes into the guide (see "Compiling Docs" in README.md)
- [x] Verify that the compiled changes look accurate by viewing the HTML site
- [ ] Have at least one other contributor review and approve your changes
