### PR TITLE
Fix indentation and spacing on Imaging Guide

### DIFF
--- a/src/imaging_guide/00_starting.md
+++ b/src/imaging_guide/00_starting.md
@@ -18,31 +18,39 @@ Advanced functionality optionally included in your Machine Request:
 # Before you create your machine request!
 
 These steps must be completed in order to ensure the image that is created is compatible with Atmosphere:
-* Remove any non-purchased, licensed software that does not allow for free and open use in the cloud.
-* Software in which the licensing otherwise prevents the use within a cloud or virtualized environment.
-* Do *NOT* install software in these directories, as they will be destroyed during the imaging process:
-* * /home/ - All files, directories, and icons located under /home/<username>/Desktop will be deleted. To preserve them, you can use /etc/skel which is the directory that will be *COPIED* to *each new user* of the VM. Note that these should be small files or starter directories.
-* * /mnt
-* * /tmp
-* * /var/log - All files and directories will be *emptied* but not destroyed, as part of the imaging process.
-* * /root - All files and directories under /root/ will be destroyed as part of the imaging process.
-* Volumes will *NOT* be copied to a new image. The files must exist on the disk.
-* Modifications to these files will be destroyed as part of the imaging process:
-* * /etc/fstab
-* * /etc/fstaf
-* * /etc/group
-* * /etc/host.allow
-* * /etc/host.conf
-* * /etc/host.deny
-* * /etc/hosts
-* * /etc/ldap.conf
-* * /etc/passwd
-* * /etc/resolve.conf
-* * /etc/shadow
-* * /etc/sshd/
-* * /etc/sysconfig/iptables
-* If you install software that logs *outside* of /var/log, be sure to *empty the file* especially if it contains secrets or otherwise confidential information about your account *prior* to making a Machine Request for imaging.
-* NOTE: The permissions of the operating system are NOT affected by the imaging process.
+
+-  Remove any non-purchased, licensed software that does not allow for free and open use in the cloud.
+
+-  Software in which the licensing otherwise prevents the use within a cloud or virtualized environment.
+
+-  Do *NOT* install software in these directories, as they will be destroyed during the imaging process:
+    - `/home/` - All files, directories, and icons located under `/home/<username>/Desktop` will be deleted. To preserve them, you can use `/etc/skel` which is the directory that will be *COPIED* to *each new user* of the VM. Note that these
+    should be small files or starter directories.
+    - `/mnt`
+    - `/tmp`
+    - `/var/log` - All files and directories will be *emptied* but not destroyed, as part of the imaging process.
+    - `/root` - All files and directories under /root/ will be destroyed as part of the imaging process.
+
+- Volumes will *NOT* be copied to a new image. The files must exist on the disk.
+
+- Modifications to these files will be destroyed as part of the imaging process:
+    - `/etc/fstab`
+    - `/etc/fstaf`
+    - `/etc/group`
+    - `/etc/host.allow`
+    - `/etc/host.conf`
+    - `/etc/host.deny`
+    - `/etc/hosts`
+    - `/etc/ldap.conf`
+    - `/etc/passwd`
+    - `/etc/resolve.conf`
+    - `/etc/shadow`
+    - `/etc/sshd/`
+    - `/etc/sysconfig/iptables`
+
+- If you install software that logs *outside* of `/var/log`, be sure to *empty the file* especially if it contains secrets or otherwise confidential information about your account *prior* to making a Machine Request for imaging.
+
+- NOTE: The permissions of the operating system are NOT affected by the imaging process.
   If you install software as
   `username:groupname`
   and you intend to provide that software to other users who launch your image, you will need to *include a Boot Script* that will change the permissions of the directory.
@@ -53,35 +61,35 @@ These steps must be completed in order to ensure the image that is created is co
 3. Click the instance name. The instance must be in Active status.
 3. In the Actions list on the right, click Image.
 4. On the Image Request form, enter the necessary information:
-  + New Image Name: Enter the name, up to 30 characters, to assign to the new image.
-  + Description of the Image: Enter the description of the image as it will appear in Atmosphere. The description should include key words that concisely describe the tools installed, the purpose of the tools (e.g., This image performs X analysis), and the initial intent of the machine image (e.g. designed for XYZ workshop).
-  + Image Tags: (Optional) Click in the field and select tags that will enhance search results for this image. You can add and remove tags later, if needed.
+    - New Image Name: Enter the name, up to 30 characters, to assign to the new image.
+    - Description of the Image: Enter the description of the image as it will appear in Atmosphere. The description should include key words that concisely describe the tools installed, the purpose of the tools (e.g., This image performs X analysis), and the initial intent of the machine image (e.g. designed for XYZ workshop).
+    - Image Tags: (Optional) Click in the field and select tags that will enhance search results for this image. You can add and remove tags later, if needed.
 5. Click Next.
 6. In the second screen:
-  + New Version Name: Enter the new (unique) name or number of the tool to distinguish this tool from others with a similar name.
-  + Change Log: Enter a brief description of the changes you made to this version of the tool.
+    - New Version Name: Enter the new (unique) name or number of the tool to distinguish this tool from others with a similar name.
+    - Change Log: Enter a brief description of the changes you made to this version of the tool.
 7. Click Next.
-8. In the Cloud for Deployment screen: 
-  + Select the cloud provider to use for the image. The choices depend on the providers to which you have been granted access.
+8. In the Cloud for Deployment screen:
+    - Select the cloud provider to use for the image. The choices depend on the providers to which you have been granted access.
 9. Click Next.
 10. In the Image Visibility screen:
-  + Select the visibility for the image. 
-  + Public: Makes the image visible to and launchable by everyone.
-  + Private: Allows only you to view and launch the image.
-  + Specific Users: Makes the image visible to and launchable only specified users.
+    - Select the visibility for the image.
+    - Public: Makes the image visible to and launchable by everyone.
+    - Private: Allows only you to view and launch the image.
+    - Specific Users: Makes the image visible to and launchable only specified users.
     If you chose Specific Users, select the users who will be able to launch the image.
 11. To access advanced options, including excluding directories from the image, adding deployment scripts that execute when the image is launched or the status changes, or requiring the user to verify understanding of any license restrictions, click Advanced Options:
 12. To exclude files from the image, list each file to exclude on a separate line and then click Next. (This step is optional. To skip this step, just click Next.)
 13. To add a deployment script, click in the search field and search for the title of the script.
-  + To create a new deployment script:
-    * Click Create New Script, enter a title for the script, and then either click URL and enter the URL to the script, or click Full Text and enter the deployment script.
-      + URL Option: URLs must start with http[s]://
-      + Full Text Option: It is expected that your script will include a shebang line ex: #!/bin/bash
-    * When done, click Create and Add, and then click Next. (Just click Next to continue to the next screen without adding a new script).
+    -  To create a new deployment script:
+        - Click Create New Script, enter a title for the script, and then either click URL and enter the URL to the script, or click Full Text and enter the deployment script.
+            - URL Option: URLs must start with `http[s]://`
+            - Full Text Option: It is expected that your script will include a shebang line ex: `#!/bin/bash`
+        - When done, click Create and Add, and then click Next. (Just click Next to continue to the next screen without adding a new script).
 14. To list any licensed software used in the image and require users to agree to the license agreement before launching, click in the search field and search for the license title.
-  + To create a new license:
-    * Click Create New License, enter a title for the license, and then either click URL and enter the URL to the license, or click Full Text and enter the full license text.
-    * When done, click Create and Add, and then click Next. (Just click Next to continue to the next screen without adding a new script).
+    - To create a new license:
+        - Click Create New License, enter a title for the license, and then either click URL and enter the URL to the license, or click Full Text and enter the full license text.
+        - When done, click Create and Add, and then click Next. (Just click Next to continue to the next screen without adding a new script).
 15. In the Review screen, click the checkbox certifying that the license does not contain any license-restricted software.
 16. Click request image.
 


### PR DESCRIPTION
## Description

The list on [this page](https://cyverse.github.io/atmosphere-guides/imaging_guide.html) under "Before you create your machine request!" is all on one line. This PR fixes that issue and provides improved indentation for the list under "Creating a Machine Request"

## Checklist before merging Pull Requests
- ~[ ] If providing a step-by-step procedure (e.g. a set of commands to run), *try following your own steps*, ensure they produce the intended result~
- [x] Run makefile to compile your changes into the guide (see "Compiling Docs" in README.md)
- [x] Verify that the compiled changes look accurate by viewing the HTML site
- [ ] If applicable, [Example link to the PR](https://example.test/doc#new_section) to give context to the documentation
- [ ] Have at least one other contributor review and approve your changes
